### PR TITLE
UUID as ID key for entities

### DIFF
--- a/templates/helper/server/req.tmpl
+++ b/templates/helper/server/req.tmpl
@@ -16,9 +16,13 @@
 
     // ReqID is similar to Req, but also processes an "id" path parameter and provides it to the
     // handler function.
-    func ReqID[Resp any](s *Server, op Operation, fn func(*http.Request, int) (*Resp, error)) http.HandlerFunc {
+    func ReqID[Resp any](s *Server, op Operation, fn func(*http.Request, {{- if $.Annotations.RestConfig.AllowClientUUIDs }} uuid.UUID {{- else }} int {{- end }}) (*Resp, error)) http.HandlerFunc {
         return func(w http.ResponseWriter, r *http.Request) {
+            {{- if $.Annotations.RestConfig.AllowClientUUIDs }}
+            id, err := uuid.Parse(r.PathValue("id"))
+            {{- else }}
             id, err := strconv.Atoi(r.PathValue("id"))
+            {{- end }}
             if err != nil {
                 handleResponse[Resp](s, w, r, op, nil, err)
                 return
@@ -44,9 +48,13 @@
 
     // ReqIDParam is similar to ReqParam, but also processes an "id" path parameter and request
     // body/query params, and provides it to the handler function.
-    func ReqIDParam[Params, Resp any](s *Server, op Operation, fn func(*http.Request, int, *Params) (*Resp, error)) http.HandlerFunc {
+    func ReqIDParam[Params, Resp any](s *Server, op Operation, fn func(*http.Request, {{- if $.Annotations.RestConfig.AllowClientUUIDs }} uuid.UUID {{- else }} int {{- end }} , *Params) (*Resp, error)) http.HandlerFunc {
         return func(w http.ResponseWriter, r *http.Request) {
+            {{- if $.Annotations.RestConfig.AllowClientUUIDs }}
+            id, err := uuid.Parse(r.PathValue("id"))
+            {{- else }}
             id, err := strconv.Atoi(r.PathValue("id"))
+            {{- end }}
             if err != nil {
                 handleResponse[Resp](s, w, r, op, nil, err)
                 return

--- a/templates/helper/server/req.tmpl
+++ b/templates/helper/server/req.tmpl
@@ -16,9 +16,9 @@
 
     // ReqID is similar to Req, but also processes an "id" path parameter and provides it to the
     // handler function.
-    func ReqID[Resp any](s *Server, op Operation, fn func(*http.Request, {{- if $.Annotations.RestConfig.AllowClientUUIDs }} uuid.UUID {{- else }} int {{- end }}) (*Resp, error)) http.HandlerFunc {
+    func ReqID[Resp any](s *Server, op Operation, fn func(*http.Request, {{- if $.Config.IDType.Ident }}{{ $.Config.IDType.Ident }} {{- else }} int {{- end}}) (*Resp, error)) http.HandlerFunc {
         return func(w http.ResponseWriter, r *http.Request) {
-            {{- if $.Annotations.RestConfig.AllowClientUUIDs }}
+            {{- if $.Config.IDType.Ident }}
             id, err := uuid.Parse(r.PathValue("id"))
             {{- else }}
             id, err := strconv.Atoi(r.PathValue("id"))
@@ -48,9 +48,9 @@
 
     // ReqIDParam is similar to ReqParam, but also processes an "id" path parameter and request
     // body/query params, and provides it to the handler function.
-    func ReqIDParam[Params, Resp any](s *Server, op Operation, fn func(*http.Request, {{- if $.Annotations.RestConfig.AllowClientUUIDs }} uuid.UUID {{- else }} int {{- end }} , *Params) (*Resp, error)) http.HandlerFunc {
+    func ReqIDParam[Params, Resp any](s *Server, op Operation, fn func(*http.Request, {{- if $.Config.IDType.Ident }}{{ $.Config.IDType.Ident }} {{- else }} int {{- end }} , *Params) (*Resp, error)) http.HandlerFunc {
         return func(w http.ResponseWriter, r *http.Request) {
-            {{- if $.Annotations.RestConfig.AllowClientUUIDs }}
+            {{- if $.Config.IDType.Ident }}
             id, err := uuid.Parse(r.PathValue("id"))
             {{- else }}
             id, err := strconv.Atoi(r.PathValue("id"))

--- a/templates/server.tmpl
+++ b/templates/server.tmpl
@@ -289,7 +289,7 @@ func UseEntContext(db *ent.Client) func(next http.Handler) http.Handler {
     {{- if and $t.ID (($t|getAnnotation).HasOperation $t.Config.Annotations.RestConfig "read") }}
         {{- $opID := getOperationIDName "read" $t nil | zpascal }}
         // {{ $opID }} maps to "GET {{ getPathName "read" $t nil false }}".
-        func (s *Server) {{ $opID }}(r *http.Request, {{ $id }} int) (*ent.{{ $t.Name }}, error) {
+        func (s *Server) {{ $opID }}(r *http.Request, {{ $id }} {{ $t.ID.Type }}) (*ent.{{ $t.Name }}, error) {
             return EagerLoad{{ $t.Name|zsingular }}(s.db.{{ $t.Name }}.Query().Where({{ $t.Package }}.ID({{ $id }}))).Only(r.Context())
         }
     {{- end }}
@@ -306,7 +306,7 @@ func UseEntContext(db *ent.Client) func(next http.Handler) http.Handler {
         {{- if and $e.Unique (($t|getAnnotation).HasOperation $t.Config.Annotations.RestConfig "read") }}
             {{- $opID := getOperationIDName "read" $t $e | zpascal }}
             // {{ $opID }} maps to "GET {{ getPathName "read" $t $e false }}".
-            func (s *Server) {{ $opID }}(r *http.Request, {{ $id }} int) (*ent.{{ $e.Type.Name }}, error) {
+            func (s *Server) {{ $opID }}(r *http.Request, {{ $id }} {{ $t.ID.Type }}) (*ent.{{ $e.Type.Name }}, error) {
                 return EagerLoad{{ $e.Type.Name|zsingular }}(s.db.{{ $t.Name }}.Query().Where({{ $t.Package }}.ID({{ $id }})).Query{{ $e.StructField }}()).Only(r.Context())
             }
         {{- end }}
@@ -315,7 +315,7 @@ func UseEntContext(db *ent.Client) func(next http.Handler) http.Handler {
         {{- if and (not $e.Unique) (($t|getAnnotation).HasOperation $t.Config.Annotations.RestConfig "list") }}
             {{- $opID := getOperationIDName "list" $t $e | zpascal }}
             // {{ $opID }} maps to "GET {{ getPathName "list" $t $e false }}".
-            func (s *Server) {{ $opID }}(r *http.Request, {{ $id }} int, p *List{{ $e.Type.Name|zsingular }}Params) (*PagedResponse[ent.{{ $e.Type.Name }}], error) {
+            func (s *Server) {{ $opID }}(r *http.Request, {{ $id }} {{ $t.ID.Type }}, p *List{{ $e.Type.Name|zsingular }}Params) (*PagedResponse[ent.{{ $e.Type.Name }}], error) {
                 return p.Exec(r.Context(), s.db.{{ $t.Name }}.Query().Where({{ $t.Package }}.ID({{ $id }})).Query{{ $e.StructField }}())
             }
         {{- end }}
@@ -334,7 +334,7 @@ func UseEntContext(db *ent.Client) func(next http.Handler) http.Handler {
     {{- if and $t.ID (($t|getAnnotation).HasOperation $t.Config.Annotations.RestConfig "update") }}
         {{- $opID := getOperationIDName "update" $t nil | zpascal }}
         // {{ $opID }} maps to "PATCH {{ getPathName "update" $t nil false }}".
-        func (s *Server) {{ $opID }}(r *http.Request, {{ $id }} int, p *Update{{ $t.Name|zsingular }}Params) (*ent.{{ $t.Name }}, error) {
+        func (s *Server) {{ $opID }}(r *http.Request, {{ $id }} {{ $t.ID.Type }}, p *Update{{ $t.Name|zsingular }}Params) (*ent.{{ $t.Name }}, error) {
             return p.Exec(r.Context(), s.db.{{ $t.Name }}.UpdateOneID({{ $id }}), s.db.{{ $t.Name }}.Query())
         }
     {{- end }}
@@ -343,7 +343,7 @@ func UseEntContext(db *ent.Client) func(next http.Handler) http.Handler {
     {{- if and $t.ID (($t|getAnnotation).HasOperation $t.Config.Annotations.RestConfig "delete") }}
         {{- $opID := getOperationIDName "delete" $t nil | zpascal }}
         // {{ $opID }} maps to "DELETE {{ getPathName "delete" $t nil false }}".
-        func (s *Server) {{ $opID }}(r *http.Request, {{ $id }} int) (*struct{}, error) {
+        func (s *Server) {{ $opID }}(r *http.Request, {{ $id }} {{ $t.ID.Type }}) (*struct{}, error) {
             return nil, s.db.{{ $t.Name }}.DeleteOneID({{ $id }}).Exec(r.Context())
         }
     {{- end }}


### PR DESCRIPTION
<!--
  🙏 Thanks for submitting a pull request to entrest! Please make sure to read our
  Contributing Guidelines, and Code of Conduct.

  ❌ You can remove any sections of this template that are not applicable to your PR.
-->

## 🚀 Changes proposed by this PR

<!-- REQUIRED:
  Please include a summary of the change and which issue is fixed, or what feature is
  implemented. Include relevant motivation and context.
-->
The extension does not work for schema files that use uuid.UUID for ID fields. This fix checks for the flag `AllowClientUUIDs` and takes necessary action.


### 🔗 Related bug reports/feature requests

<!--
  Does this PR relate to any bug reports and/or feature requests? Some examples:
  ❌ Remove section if there are no existing requests and/or issues.
-->
- fixes #69 


### 🧰 Type of change

<!-- REQUIRED: Please mark which one applies to this change, ❌ remove the others. -->
- [ X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected).
- [ ] This change requires (or is) a documentation update.

### 📝 Notes to reviewer

<!--
  If needed, leave any special pointers for reviewing or testing your PR. If necessary,
  include things like screenshots (where beneficial), to help demonstrate the changes.
-->

### 🤝 Requirements

- [x] ✍ I have read and agree to this projects [Code of Conduct](../../blob/master/.github/CODE_OF_CONDUCT.md).
- [x] ✍ I have read and agree to this projects [Contribution Guidelines](../../blob/master/.github/CONTRIBUTING.md).
- [x] ✍ I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] 🔎 I have performed a self-review of my own changes.
- [x] 🎨 My changes follow the style guidelines of this project.
<!-- Include the below if this is a code change, if just documentation, ❌ remove this section. -->
- [x] 💬 My changes as properly commented, primarily for hard-to-understand areas.
- [x] 📝 I have made corresponding changes to the documentation.
- [x] 🧪 I have included tests (if necessary) for this change.
