### PR TITLE
Custom ID support (string, UUID, etc) and misc bug fixes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,10 +31,10 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: docs/pnpm-lock.yaml
       - run: make docs-build
-      - if: ${{ github.event_name != 'pull_request' }}
+      - if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event_name != 'pull_request' }}
         uses: actions/upload-pages-artifact@v3
         with:
           path: docs/dist/
-      - if: ${{ github.event_name != 'pull_request' }}
+      - if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event_name != 'pull_request' }}
         id: deployment
         uses: actions/deploy-pages@v4

--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-chi/chi/v5 v5.2.0
 	github.com/go-playground/form/v4 v4.2.1
 	github.com/google/go-github/v66 v66.0.0
+	github.com/google/uuid v1.6.0
 	github.com/lrstanley/entrest v0.0.0-20241123215036-448ac7a7c665
 	github.com/ogen-go/ogen v1.8.1
 	github.com/stretchr/testify v1.10.0
@@ -32,7 +33,6 @@ require (
 	github.com/go-openapi/inflect v0.21.0 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hcl/v2 v2.23.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/_examples/kitchensink/internal/database/ent/client.go
+++ b/_examples/kitchensink/internal/database/ent/client.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"reflect"
 
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/migrate"
 
 	"entgo.io/ent"
@@ -1239,7 +1240,7 @@ func (c *UserClient) UpdateOne(u *User) *UserUpdateOne {
 }
 
 // UpdateOneID returns an update builder for the given id.
-func (c *UserClient) UpdateOneID(id int) *UserUpdateOne {
+func (c *UserClient) UpdateOneID(id uuid.UUID) *UserUpdateOne {
 	mutation := newUserMutation(c.config, OpUpdateOne, withUserID(id))
 	return &UserUpdateOne{config: c.config, hooks: c.Hooks(), mutation: mutation}
 }
@@ -1256,7 +1257,7 @@ func (c *UserClient) DeleteOne(u *User) *UserDeleteOne {
 }
 
 // DeleteOneID returns a builder for deleting the given entity by its id.
-func (c *UserClient) DeleteOneID(id int) *UserDeleteOne {
+func (c *UserClient) DeleteOneID(id uuid.UUID) *UserDeleteOne {
 	builder := c.Delete().Where(user.ID(id))
 	builder.mutation.id = &id
 	builder.mutation.op = OpDeleteOne
@@ -1273,12 +1274,12 @@ func (c *UserClient) Query() *UserQuery {
 }
 
 // Get returns a User entity by its id.
-func (c *UserClient) Get(ctx context.Context, id int) (*User, error) {
+func (c *UserClient) Get(ctx context.Context, id uuid.UUID) (*User, error) {
 	return c.Query().Where(user.ID(id)).Only(ctx)
 }
 
 // GetX is like Get, but panics if an error occurs.
-func (c *UserClient) GetX(ctx context.Context, id int) *User {
+func (c *UserClient) GetX(ctx context.Context, id uuid.UUID) *User {
 	obj, err := c.Get(ctx, id)
 	if err != nil {
 		panic(err)

--- a/_examples/kitchensink/internal/database/ent/follows.go
+++ b/_examples/kitchensink/internal/database/ent/follows.go
@@ -9,6 +9,7 @@ import (
 
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/follows"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/pet"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/user"
@@ -20,7 +21,7 @@ type Follows struct {
 	// FollowedAt holds the value of the "followed_at" field.
 	FollowedAt time.Time `json:"followed_at"`
 	// UserID holds the value of the "user_id" field.
-	UserID int `json:"user_id"`
+	UserID uuid.UUID `json:"user_id"`
 	// PetID holds the value of the "pet_id" field.
 	PetID int `json:"pet_id"`
 	// Edges holds the relations/edges for other nodes in the graph.
@@ -67,10 +68,12 @@ func (*Follows) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case follows.FieldUserID, follows.FieldPetID:
+		case follows.FieldPetID:
 			values[i] = new(sql.NullInt64)
 		case follows.FieldFollowedAt:
 			values[i] = new(sql.NullTime)
+		case follows.FieldUserID:
+			values[i] = new(uuid.UUID)
 		default:
 			values[i] = new(sql.UnknownType)
 		}
@@ -93,10 +96,10 @@ func (f *Follows) assignValues(columns []string, values []any) error {
 				f.FollowedAt = value.Time
 			}
 		case follows.FieldUserID:
-			if value, ok := values[i].(*sql.NullInt64); !ok {
+			if value, ok := values[i].(*uuid.UUID); !ok {
 				return fmt.Errorf("unexpected type %T for field user_id", values[i])
-			} else if value.Valid {
-				f.UserID = int(value.Int64)
+			} else if value != nil {
+				f.UserID = *value
 			}
 		case follows.FieldPetID:
 			if value, ok := values[i].(*sql.NullInt64); !ok {

--- a/_examples/kitchensink/internal/database/ent/follows/where.go
+++ b/_examples/kitchensink/internal/database/ent/follows/where.go
@@ -7,6 +7,7 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/predicate"
 )
 
@@ -16,7 +17,7 @@ func FollowedAt(v time.Time) predicate.Follows {
 }
 
 // UserID applies equality check predicate on the "user_id" field. It's identical to UserIDEQ.
-func UserID(v int) predicate.Follows {
+func UserID(v uuid.UUID) predicate.Follows {
 	return predicate.Follows(sql.FieldEQ(FieldUserID, v))
 }
 
@@ -66,22 +67,22 @@ func FollowedAtLTE(v time.Time) predicate.Follows {
 }
 
 // UserIDEQ applies the EQ predicate on the "user_id" field.
-func UserIDEQ(v int) predicate.Follows {
+func UserIDEQ(v uuid.UUID) predicate.Follows {
 	return predicate.Follows(sql.FieldEQ(FieldUserID, v))
 }
 
 // UserIDNEQ applies the NEQ predicate on the "user_id" field.
-func UserIDNEQ(v int) predicate.Follows {
+func UserIDNEQ(v uuid.UUID) predicate.Follows {
 	return predicate.Follows(sql.FieldNEQ(FieldUserID, v))
 }
 
 // UserIDIn applies the In predicate on the "user_id" field.
-func UserIDIn(vs ...int) predicate.Follows {
+func UserIDIn(vs ...uuid.UUID) predicate.Follows {
 	return predicate.Follows(sql.FieldIn(FieldUserID, vs...))
 }
 
 // UserIDNotIn applies the NotIn predicate on the "user_id" field.
-func UserIDNotIn(vs ...int) predicate.Follows {
+func UserIDNotIn(vs ...uuid.UUID) predicate.Follows {
 	return predicate.Follows(sql.FieldNotIn(FieldUserID, vs...))
 }
 

--- a/_examples/kitchensink/internal/database/ent/follows_create.go
+++ b/_examples/kitchensink/internal/database/ent/follows_create.go
@@ -10,6 +10,7 @@ import (
 
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/follows"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/pet"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/user"
@@ -37,8 +38,8 @@ func (fc *FollowsCreate) SetNillableFollowedAt(t *time.Time) *FollowsCreate {
 }
 
 // SetUserID sets the "user_id" field.
-func (fc *FollowsCreate) SetUserID(i int) *FollowsCreate {
-	fc.mutation.SetUserID(i)
+func (fc *FollowsCreate) SetUserID(u uuid.UUID) *FollowsCreate {
+	fc.mutation.SetUserID(u)
 	return fc
 }
 
@@ -150,7 +151,7 @@ func (fc *FollowsCreate) createSpec() (*Follows, *sqlgraph.CreateSpec) {
 			Columns: []string{follows.UserColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {

--- a/_examples/kitchensink/internal/database/ent/follows_query.go
+++ b/_examples/kitchensink/internal/database/ent/follows_query.go
@@ -10,6 +10,7 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/follows"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/pet"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/predicate"
@@ -372,8 +373,8 @@ func (fq *FollowsQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Foll
 }
 
 func (fq *FollowsQuery) loadUser(ctx context.Context, query *UserQuery, nodes []*Follows, init func(*Follows), assign func(*Follows, *User)) error {
-	ids := make([]int, 0, len(nodes))
-	nodeids := make(map[int][]*Follows)
+	ids := make([]uuid.UUID, 0, len(nodes))
+	nodeids := make(map[uuid.UUID][]*Follows)
 	for i := range nodes {
 		fk := nodes[i].UserID
 		if _, ok := nodeids[fk]; !ok {

--- a/_examples/kitchensink/internal/database/ent/follows_update.go
+++ b/_examples/kitchensink/internal/database/ent/follows_update.go
@@ -11,6 +11,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/follows"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/pet"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/predicate"
@@ -45,15 +46,15 @@ func (fu *FollowsUpdate) SetNillableFollowedAt(t *time.Time) *FollowsUpdate {
 }
 
 // SetUserID sets the "user_id" field.
-func (fu *FollowsUpdate) SetUserID(i int) *FollowsUpdate {
-	fu.mutation.SetUserID(i)
+func (fu *FollowsUpdate) SetUserID(u uuid.UUID) *FollowsUpdate {
+	fu.mutation.SetUserID(u)
 	return fu
 }
 
 // SetNillableUserID sets the "user_id" field if the given value is not nil.
-func (fu *FollowsUpdate) SetNillableUserID(i *int) *FollowsUpdate {
-	if i != nil {
-		fu.SetUserID(*i)
+func (fu *FollowsUpdate) SetNillableUserID(u *uuid.UUID) *FollowsUpdate {
+	if u != nil {
+		fu.SetUserID(*u)
 	}
 	return fu
 }
@@ -141,7 +142,7 @@ func (fu *FollowsUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if err := fu.check(); err != nil {
 		return n, err
 	}
-	_spec := sqlgraph.NewUpdateSpec(follows.Table, follows.Columns, sqlgraph.NewFieldSpec(follows.FieldUserID, field.TypeInt), sqlgraph.NewFieldSpec(follows.FieldPetID, field.TypeInt))
+	_spec := sqlgraph.NewUpdateSpec(follows.Table, follows.Columns, sqlgraph.NewFieldSpec(follows.FieldUserID, field.TypeUUID), sqlgraph.NewFieldSpec(follows.FieldPetID, field.TypeInt))
 	if ps := fu.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
@@ -160,7 +161,7 @@ func (fu *FollowsUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Columns: []string{follows.UserColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
@@ -173,7 +174,7 @@ func (fu *FollowsUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Columns: []string{follows.UserColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {
@@ -245,15 +246,15 @@ func (fuo *FollowsUpdateOne) SetNillableFollowedAt(t *time.Time) *FollowsUpdateO
 }
 
 // SetUserID sets the "user_id" field.
-func (fuo *FollowsUpdateOne) SetUserID(i int) *FollowsUpdateOne {
-	fuo.mutation.SetUserID(i)
+func (fuo *FollowsUpdateOne) SetUserID(u uuid.UUID) *FollowsUpdateOne {
+	fuo.mutation.SetUserID(u)
 	return fuo
 }
 
 // SetNillableUserID sets the "user_id" field if the given value is not nil.
-func (fuo *FollowsUpdateOne) SetNillableUserID(i *int) *FollowsUpdateOne {
-	if i != nil {
-		fuo.SetUserID(*i)
+func (fuo *FollowsUpdateOne) SetNillableUserID(u *uuid.UUID) *FollowsUpdateOne {
+	if u != nil {
+		fuo.SetUserID(*u)
 	}
 	return fuo
 }
@@ -354,7 +355,7 @@ func (fuo *FollowsUpdateOne) sqlSave(ctx context.Context) (_node *Follows, err e
 	if err := fuo.check(); err != nil {
 		return _node, err
 	}
-	_spec := sqlgraph.NewUpdateSpec(follows.Table, follows.Columns, sqlgraph.NewFieldSpec(follows.FieldUserID, field.TypeInt), sqlgraph.NewFieldSpec(follows.FieldPetID, field.TypeInt))
+	_spec := sqlgraph.NewUpdateSpec(follows.Table, follows.Columns, sqlgraph.NewFieldSpec(follows.FieldUserID, field.TypeUUID), sqlgraph.NewFieldSpec(follows.FieldPetID, field.TypeInt))
 	if id, ok := fuo.mutation.UserID(); !ok {
 		return nil, &ValidationError{Name: "user_id", err: errors.New(`ent: missing "Follows.user_id" for update`)}
 	} else {
@@ -392,7 +393,7 @@ func (fuo *FollowsUpdateOne) sqlSave(ctx context.Context) (_node *Follows, err e
 			Columns: []string{follows.UserColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
@@ -405,7 +406,7 @@ func (fuo *FollowsUpdateOne) sqlSave(ctx context.Context) (_node *Follows, err e
 			Columns: []string{follows.UserColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {

--- a/_examples/kitchensink/internal/database/ent/friendship.go
+++ b/_examples/kitchensink/internal/database/ent/friendship.go
@@ -9,6 +9,7 @@ import (
 
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/friendship"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/user"
 )
@@ -21,9 +22,9 @@ type Friendship struct {
 	// CreatedAt holds the value of the "created_at" field.
 	CreatedAt time.Time `json:"created_at"`
 	// UserID holds the value of the "user_id" field.
-	UserID int `json:"user_id"`
+	UserID uuid.UUID `json:"user_id"`
 	// FriendID holds the value of the "friend_id" field.
-	FriendID int `json:"friend_id"`
+	FriendID uuid.UUID `json:"friend_id"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the FriendshipQuery when eager-loading is set.
 	Edges        FriendshipEdges `json:"edges"`
@@ -68,10 +69,12 @@ func (*Friendship) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case friendship.FieldID, friendship.FieldUserID, friendship.FieldFriendID:
+		case friendship.FieldID:
 			values[i] = new(sql.NullInt64)
 		case friendship.FieldCreatedAt:
 			values[i] = new(sql.NullTime)
+		case friendship.FieldUserID, friendship.FieldFriendID:
+			values[i] = new(uuid.UUID)
 		default:
 			values[i] = new(sql.UnknownType)
 		}
@@ -100,16 +103,16 @@ func (f *Friendship) assignValues(columns []string, values []any) error {
 				f.CreatedAt = value.Time
 			}
 		case friendship.FieldUserID:
-			if value, ok := values[i].(*sql.NullInt64); !ok {
+			if value, ok := values[i].(*uuid.UUID); !ok {
 				return fmt.Errorf("unexpected type %T for field user_id", values[i])
-			} else if value.Valid {
-				f.UserID = int(value.Int64)
+			} else if value != nil {
+				f.UserID = *value
 			}
 		case friendship.FieldFriendID:
-			if value, ok := values[i].(*sql.NullInt64); !ok {
+			if value, ok := values[i].(*uuid.UUID); !ok {
 				return fmt.Errorf("unexpected type %T for field friend_id", values[i])
-			} else if value.Valid {
-				f.FriendID = int(value.Int64)
+			} else if value != nil {
+				f.FriendID = *value
 			}
 		default:
 			f.selectValues.Set(columns[i], values[i])

--- a/_examples/kitchensink/internal/database/ent/friendship/where.go
+++ b/_examples/kitchensink/internal/database/ent/friendship/where.go
@@ -7,6 +7,7 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/predicate"
 )
 
@@ -61,12 +62,12 @@ func CreatedAt(v time.Time) predicate.Friendship {
 }
 
 // UserID applies equality check predicate on the "user_id" field. It's identical to UserIDEQ.
-func UserID(v int) predicate.Friendship {
+func UserID(v uuid.UUID) predicate.Friendship {
 	return predicate.Friendship(sql.FieldEQ(FieldUserID, v))
 }
 
 // FriendID applies equality check predicate on the "friend_id" field. It's identical to FriendIDEQ.
-func FriendID(v int) predicate.Friendship {
+func FriendID(v uuid.UUID) predicate.Friendship {
 	return predicate.Friendship(sql.FieldEQ(FieldFriendID, v))
 }
 
@@ -111,42 +112,42 @@ func CreatedAtLTE(v time.Time) predicate.Friendship {
 }
 
 // UserIDEQ applies the EQ predicate on the "user_id" field.
-func UserIDEQ(v int) predicate.Friendship {
+func UserIDEQ(v uuid.UUID) predicate.Friendship {
 	return predicate.Friendship(sql.FieldEQ(FieldUserID, v))
 }
 
 // UserIDNEQ applies the NEQ predicate on the "user_id" field.
-func UserIDNEQ(v int) predicate.Friendship {
+func UserIDNEQ(v uuid.UUID) predicate.Friendship {
 	return predicate.Friendship(sql.FieldNEQ(FieldUserID, v))
 }
 
 // UserIDIn applies the In predicate on the "user_id" field.
-func UserIDIn(vs ...int) predicate.Friendship {
+func UserIDIn(vs ...uuid.UUID) predicate.Friendship {
 	return predicate.Friendship(sql.FieldIn(FieldUserID, vs...))
 }
 
 // UserIDNotIn applies the NotIn predicate on the "user_id" field.
-func UserIDNotIn(vs ...int) predicate.Friendship {
+func UserIDNotIn(vs ...uuid.UUID) predicate.Friendship {
 	return predicate.Friendship(sql.FieldNotIn(FieldUserID, vs...))
 }
 
 // FriendIDEQ applies the EQ predicate on the "friend_id" field.
-func FriendIDEQ(v int) predicate.Friendship {
+func FriendIDEQ(v uuid.UUID) predicate.Friendship {
 	return predicate.Friendship(sql.FieldEQ(FieldFriendID, v))
 }
 
 // FriendIDNEQ applies the NEQ predicate on the "friend_id" field.
-func FriendIDNEQ(v int) predicate.Friendship {
+func FriendIDNEQ(v uuid.UUID) predicate.Friendship {
 	return predicate.Friendship(sql.FieldNEQ(FieldFriendID, v))
 }
 
 // FriendIDIn applies the In predicate on the "friend_id" field.
-func FriendIDIn(vs ...int) predicate.Friendship {
+func FriendIDIn(vs ...uuid.UUID) predicate.Friendship {
 	return predicate.Friendship(sql.FieldIn(FieldFriendID, vs...))
 }
 
 // FriendIDNotIn applies the NotIn predicate on the "friend_id" field.
-func FriendIDNotIn(vs ...int) predicate.Friendship {
+func FriendIDNotIn(vs ...uuid.UUID) predicate.Friendship {
 	return predicate.Friendship(sql.FieldNotIn(FieldFriendID, vs...))
 }
 

--- a/_examples/kitchensink/internal/database/ent/friendship_create.go
+++ b/_examples/kitchensink/internal/database/ent/friendship_create.go
@@ -10,6 +10,7 @@ import (
 
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/friendship"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/user"
 )
@@ -36,14 +37,14 @@ func (fc *FriendshipCreate) SetNillableCreatedAt(t *time.Time) *FriendshipCreate
 }
 
 // SetUserID sets the "user_id" field.
-func (fc *FriendshipCreate) SetUserID(i int) *FriendshipCreate {
-	fc.mutation.SetUserID(i)
+func (fc *FriendshipCreate) SetUserID(u uuid.UUID) *FriendshipCreate {
+	fc.mutation.SetUserID(u)
 	return fc
 }
 
 // SetFriendID sets the "friend_id" field.
-func (fc *FriendshipCreate) SetFriendID(i int) *FriendshipCreate {
-	fc.mutation.SetFriendID(i)
+func (fc *FriendshipCreate) SetFriendID(u uuid.UUID) *FriendshipCreate {
+	fc.mutation.SetFriendID(u)
 	return fc
 }
 
@@ -153,7 +154,7 @@ func (fc *FriendshipCreate) createSpec() (*Friendship, *sqlgraph.CreateSpec) {
 			Columns: []string{friendship.UserColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {
@@ -170,7 +171,7 @@ func (fc *FriendshipCreate) createSpec() (*Friendship, *sqlgraph.CreateSpec) {
 			Columns: []string{friendship.FriendColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {

--- a/_examples/kitchensink/internal/database/ent/friendship_query.go
+++ b/_examples/kitchensink/internal/database/ent/friendship_query.go
@@ -11,6 +11,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/friendship"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/predicate"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/user"
@@ -444,8 +445,8 @@ func (fq *FriendshipQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*F
 }
 
 func (fq *FriendshipQuery) loadUser(ctx context.Context, query *UserQuery, nodes []*Friendship, init func(*Friendship), assign func(*Friendship, *User)) error {
-	ids := make([]int, 0, len(nodes))
-	nodeids := make(map[int][]*Friendship)
+	ids := make([]uuid.UUID, 0, len(nodes))
+	nodeids := make(map[uuid.UUID][]*Friendship)
 	for i := range nodes {
 		fk := nodes[i].UserID
 		if _, ok := nodeids[fk]; !ok {
@@ -473,8 +474,8 @@ func (fq *FriendshipQuery) loadUser(ctx context.Context, query *UserQuery, nodes
 	return nil
 }
 func (fq *FriendshipQuery) loadFriend(ctx context.Context, query *UserQuery, nodes []*Friendship, init func(*Friendship), assign func(*Friendship, *User)) error {
-	ids := make([]int, 0, len(nodes))
-	nodeids := make(map[int][]*Friendship)
+	ids := make([]uuid.UUID, 0, len(nodes))
+	nodeids := make(map[uuid.UUID][]*Friendship)
 	for i := range nodes {
 		fk := nodes[i].FriendID
 		if _, ok := nodeids[fk]; !ok {

--- a/_examples/kitchensink/internal/database/ent/friendship_update.go
+++ b/_examples/kitchensink/internal/database/ent/friendship_update.go
@@ -11,6 +11,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/friendship"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/predicate"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/user"
@@ -44,29 +45,29 @@ func (fu *FriendshipUpdate) SetNillableCreatedAt(t *time.Time) *FriendshipUpdate
 }
 
 // SetUserID sets the "user_id" field.
-func (fu *FriendshipUpdate) SetUserID(i int) *FriendshipUpdate {
-	fu.mutation.SetUserID(i)
+func (fu *FriendshipUpdate) SetUserID(u uuid.UUID) *FriendshipUpdate {
+	fu.mutation.SetUserID(u)
 	return fu
 }
 
 // SetNillableUserID sets the "user_id" field if the given value is not nil.
-func (fu *FriendshipUpdate) SetNillableUserID(i *int) *FriendshipUpdate {
-	if i != nil {
-		fu.SetUserID(*i)
+func (fu *FriendshipUpdate) SetNillableUserID(u *uuid.UUID) *FriendshipUpdate {
+	if u != nil {
+		fu.SetUserID(*u)
 	}
 	return fu
 }
 
 // SetFriendID sets the "friend_id" field.
-func (fu *FriendshipUpdate) SetFriendID(i int) *FriendshipUpdate {
-	fu.mutation.SetFriendID(i)
+func (fu *FriendshipUpdate) SetFriendID(u uuid.UUID) *FriendshipUpdate {
+	fu.mutation.SetFriendID(u)
 	return fu
 }
 
 // SetNillableFriendID sets the "friend_id" field if the given value is not nil.
-func (fu *FriendshipUpdate) SetNillableFriendID(i *int) *FriendshipUpdate {
-	if i != nil {
-		fu.SetFriendID(*i)
+func (fu *FriendshipUpdate) SetNillableFriendID(u *uuid.UUID) *FriendshipUpdate {
+	if u != nil {
+		fu.SetFriendID(*u)
 	}
 	return fu
 }
@@ -159,7 +160,7 @@ func (fu *FriendshipUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Columns: []string{friendship.UserColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
@@ -172,7 +173,7 @@ func (fu *FriendshipUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Columns: []string{friendship.UserColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {
@@ -188,7 +189,7 @@ func (fu *FriendshipUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Columns: []string{friendship.FriendColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
@@ -201,7 +202,7 @@ func (fu *FriendshipUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Columns: []string{friendship.FriendColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {
@@ -244,29 +245,29 @@ func (fuo *FriendshipUpdateOne) SetNillableCreatedAt(t *time.Time) *FriendshipUp
 }
 
 // SetUserID sets the "user_id" field.
-func (fuo *FriendshipUpdateOne) SetUserID(i int) *FriendshipUpdateOne {
-	fuo.mutation.SetUserID(i)
+func (fuo *FriendshipUpdateOne) SetUserID(u uuid.UUID) *FriendshipUpdateOne {
+	fuo.mutation.SetUserID(u)
 	return fuo
 }
 
 // SetNillableUserID sets the "user_id" field if the given value is not nil.
-func (fuo *FriendshipUpdateOne) SetNillableUserID(i *int) *FriendshipUpdateOne {
-	if i != nil {
-		fuo.SetUserID(*i)
+func (fuo *FriendshipUpdateOne) SetNillableUserID(u *uuid.UUID) *FriendshipUpdateOne {
+	if u != nil {
+		fuo.SetUserID(*u)
 	}
 	return fuo
 }
 
 // SetFriendID sets the "friend_id" field.
-func (fuo *FriendshipUpdateOne) SetFriendID(i int) *FriendshipUpdateOne {
-	fuo.mutation.SetFriendID(i)
+func (fuo *FriendshipUpdateOne) SetFriendID(u uuid.UUID) *FriendshipUpdateOne {
+	fuo.mutation.SetFriendID(u)
 	return fuo
 }
 
 // SetNillableFriendID sets the "friend_id" field if the given value is not nil.
-func (fuo *FriendshipUpdateOne) SetNillableFriendID(i *int) *FriendshipUpdateOne {
-	if i != nil {
-		fuo.SetFriendID(*i)
+func (fuo *FriendshipUpdateOne) SetNillableFriendID(u *uuid.UUID) *FriendshipUpdateOne {
+	if u != nil {
+		fuo.SetFriendID(*u)
 	}
 	return fuo
 }
@@ -389,7 +390,7 @@ func (fuo *FriendshipUpdateOne) sqlSave(ctx context.Context) (_node *Friendship,
 			Columns: []string{friendship.UserColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
@@ -402,7 +403,7 @@ func (fuo *FriendshipUpdateOne) sqlSave(ctx context.Context) (_node *Friendship,
 			Columns: []string{friendship.UserColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {
@@ -418,7 +419,7 @@ func (fuo *FriendshipUpdateOne) sqlSave(ctx context.Context) (_node *Friendship,
 			Columns: []string{friendship.FriendColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
@@ -431,7 +432,7 @@ func (fuo *FriendshipUpdateOne) sqlSave(ctx context.Context) (_node *Friendship,
 			Columns: []string{friendship.FriendColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {

--- a/_examples/kitchensink/internal/database/ent/migrate/schema.go
+++ b/_examples/kitchensink/internal/database/ent/migrate/schema.go
@@ -29,7 +29,7 @@ var (
 	// FollowsColumns holds the columns for the "follows" table.
 	FollowsColumns = []*schema.Column{
 		{Name: "followed_at", Type: field.TypeTime},
-		{Name: "user_id", Type: field.TypeInt},
+		{Name: "user_id", Type: field.TypeUUID},
 		{Name: "pet_id", Type: field.TypeInt},
 	}
 	// FollowsTable holds the schema information for the "follows" table.
@@ -56,8 +56,8 @@ var (
 	FriendshipsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "created_at", Type: field.TypeTime},
-		{Name: "user_id", Type: field.TypeInt},
-		{Name: "friend_id", Type: field.TypeInt},
+		{Name: "user_id", Type: field.TypeUUID},
+		{Name: "friend_id", Type: field.TypeUUID},
 	}
 	// FriendshipsTable holds the schema information for the "friendships" table.
 	FriendshipsTable = &schema.Table{
@@ -93,7 +93,7 @@ var (
 		{Name: "nicknames", Type: field.TypeJSON, Nullable: true},
 		{Name: "age", Type: field.TypeInt},
 		{Name: "type", Type: field.TypeEnum, Enums: []string{"DOG", "CAT", "BIRD", "FISH", "AMPHIBIAN", "REPTILE", "OTHER"}},
-		{Name: "user_pets", Type: field.TypeInt, Nullable: true},
+		{Name: "user_pets", Type: field.TypeUUID, Nullable: true},
 	}
 	// PetsTable holds the schema information for the "pets" table.
 	PetsTable = &schema.Table{
@@ -135,7 +135,7 @@ var (
 	}
 	// UsersColumns holds the columns for the "users" table.
 	UsersColumns = []*schema.Column{
-		{Name: "id", Type: field.TypeInt, Increment: true},
+		{Name: "id", Type: field.TypeUUID, Unique: true},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "name", Type: field.TypeString},

--- a/_examples/kitchensink/internal/database/ent/mutation.go
+++ b/_examples/kitchensink/internal/database/ent/mutation.go
@@ -12,6 +12,7 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"github.com/google/go-github/v66/github"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/category"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/follows"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/friendship"
@@ -939,7 +940,7 @@ type FollowsMutation struct {
 	typ           string
 	followed_at   *time.Time
 	clearedFields map[string]struct{}
-	user          *int
+	user          *uuid.UUID
 	cleareduser   bool
 	pet           *int
 	clearedpet    bool
@@ -1006,12 +1007,12 @@ func (m *FollowsMutation) ResetFollowedAt() {
 }
 
 // SetUserID sets the "user_id" field.
-func (m *FollowsMutation) SetUserID(i int) {
-	m.user = &i
+func (m *FollowsMutation) SetUserID(u uuid.UUID) {
+	m.user = &u
 }
 
 // UserID returns the value of the "user_id" field in the mutation.
-func (m *FollowsMutation) UserID() (r int, exists bool) {
+func (m *FollowsMutation) UserID() (r uuid.UUID, exists bool) {
 	v := m.user
 	if v == nil {
 		return
@@ -1057,7 +1058,7 @@ func (m *FollowsMutation) UserCleared() bool {
 // UserIDs returns the "user" edge IDs in the mutation.
 // Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
 // UserID instead. It exists only for internal usage by the builders.
-func (m *FollowsMutation) UserIDs() (ids []int) {
+func (m *FollowsMutation) UserIDs() (ids []uuid.UUID) {
 	if id := m.user; id != nil {
 		ids = append(ids, *id)
 	}
@@ -1179,7 +1180,7 @@ func (m *FollowsMutation) SetField(name string, value ent.Value) error {
 		m.SetFollowedAt(v)
 		return nil
 	case follows.FieldUserID:
-		v, ok := value.(int)
+		v, ok := value.(uuid.UUID)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
@@ -1357,9 +1358,9 @@ type FriendshipMutation struct {
 	id            *int
 	created_at    *time.Time
 	clearedFields map[string]struct{}
-	user          *int
+	user          *uuid.UUID
 	cleareduser   bool
-	friend        *int
+	friend        *uuid.UUID
 	clearedfriend bool
 	done          bool
 	oldValue      func(context.Context) (*Friendship, error)
@@ -1501,12 +1502,12 @@ func (m *FriendshipMutation) ResetCreatedAt() {
 }
 
 // SetUserID sets the "user_id" field.
-func (m *FriendshipMutation) SetUserID(i int) {
-	m.user = &i
+func (m *FriendshipMutation) SetUserID(u uuid.UUID) {
+	m.user = &u
 }
 
 // UserID returns the value of the "user_id" field in the mutation.
-func (m *FriendshipMutation) UserID() (r int, exists bool) {
+func (m *FriendshipMutation) UserID() (r uuid.UUID, exists bool) {
 	v := m.user
 	if v == nil {
 		return
@@ -1517,7 +1518,7 @@ func (m *FriendshipMutation) UserID() (r int, exists bool) {
 // OldUserID returns the old "user_id" field's value of the Friendship entity.
 // If the Friendship object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *FriendshipMutation) OldUserID(ctx context.Context) (v int, err error) {
+func (m *FriendshipMutation) OldUserID(ctx context.Context) (v uuid.UUID, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldUserID is only allowed on UpdateOne operations")
 	}
@@ -1537,12 +1538,12 @@ func (m *FriendshipMutation) ResetUserID() {
 }
 
 // SetFriendID sets the "friend_id" field.
-func (m *FriendshipMutation) SetFriendID(i int) {
-	m.friend = &i
+func (m *FriendshipMutation) SetFriendID(u uuid.UUID) {
+	m.friend = &u
 }
 
 // FriendID returns the value of the "friend_id" field in the mutation.
-func (m *FriendshipMutation) FriendID() (r int, exists bool) {
+func (m *FriendshipMutation) FriendID() (r uuid.UUID, exists bool) {
 	v := m.friend
 	if v == nil {
 		return
@@ -1553,7 +1554,7 @@ func (m *FriendshipMutation) FriendID() (r int, exists bool) {
 // OldFriendID returns the old "friend_id" field's value of the Friendship entity.
 // If the Friendship object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *FriendshipMutation) OldFriendID(ctx context.Context) (v int, err error) {
+func (m *FriendshipMutation) OldFriendID(ctx context.Context) (v uuid.UUID, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldFriendID is only allowed on UpdateOne operations")
 	}
@@ -1586,7 +1587,7 @@ func (m *FriendshipMutation) UserCleared() bool {
 // UserIDs returns the "user" edge IDs in the mutation.
 // Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
 // UserID instead. It exists only for internal usage by the builders.
-func (m *FriendshipMutation) UserIDs() (ids []int) {
+func (m *FriendshipMutation) UserIDs() (ids []uuid.UUID) {
 	if id := m.user; id != nil {
 		ids = append(ids, *id)
 	}
@@ -1613,7 +1614,7 @@ func (m *FriendshipMutation) FriendCleared() bool {
 // FriendIDs returns the "friend" edge IDs in the mutation.
 // Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
 // FriendID instead. It exists only for internal usage by the builders.
-func (m *FriendshipMutation) FriendIDs() (ids []int) {
+func (m *FriendshipMutation) FriendIDs() (ids []uuid.UUID) {
 	if id := m.friend; id != nil {
 		ids = append(ids, *id)
 	}
@@ -1716,14 +1717,14 @@ func (m *FriendshipMutation) SetField(name string, value ent.Value) error {
 		m.SetCreatedAt(v)
 		return nil
 	case friendship.FieldUserID:
-		v, ok := value.(int)
+		v, ok := value.(uuid.UUID)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetUserID(v)
 		return nil
 	case friendship.FieldFriendID:
-		v, ok := value.(int)
+		v, ok := value.(uuid.UUID)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
@@ -1736,16 +1737,13 @@ func (m *FriendshipMutation) SetField(name string, value ent.Value) error {
 // AddedFields returns all numeric fields that were incremented/decremented during
 // this mutation.
 func (m *FriendshipMutation) AddedFields() []string {
-	var fields []string
-	return fields
+	return nil
 }
 
 // AddedField returns the numeric value that was incremented/decremented on a field
 // with the given name. The second boolean return value indicates that this field
 // was not set, or was not defined in the schema.
 func (m *FriendshipMutation) AddedField(name string) (ent.Value, bool) {
-	switch name {
-	}
 	return nil, false
 }
 
@@ -1902,13 +1900,13 @@ type PetMutation struct {
 	categories         map[int]struct{}
 	removedcategories  map[int]struct{}
 	clearedcategories  bool
-	owner              *int
+	owner              *uuid.UUID
 	clearedowner       bool
 	friends            map[int]struct{}
 	removedfriends     map[int]struct{}
 	clearedfriends     bool
-	followed_by        map[int]struct{}
-	removedfollowed_by map[int]struct{}
+	followed_by        map[uuid.UUID]struct{}
+	removedfollowed_by map[uuid.UUID]struct{}
 	clearedfollowed_by bool
 	done               bool
 	oldValue           func(context.Context) (*Pet, error)
@@ -2267,7 +2265,7 @@ func (m *PetMutation) ResetCategories() {
 }
 
 // SetOwnerID sets the "owner" edge to the User entity by id.
-func (m *PetMutation) SetOwnerID(id int) {
+func (m *PetMutation) SetOwnerID(id uuid.UUID) {
 	m.owner = &id
 }
 
@@ -2282,7 +2280,7 @@ func (m *PetMutation) OwnerCleared() bool {
 }
 
 // OwnerID returns the "owner" edge ID in the mutation.
-func (m *PetMutation) OwnerID() (id int, exists bool) {
+func (m *PetMutation) OwnerID() (id uuid.UUID, exists bool) {
 	if m.owner != nil {
 		return *m.owner, true
 	}
@@ -2292,7 +2290,7 @@ func (m *PetMutation) OwnerID() (id int, exists bool) {
 // OwnerIDs returns the "owner" edge IDs in the mutation.
 // Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
 // OwnerID instead. It exists only for internal usage by the builders.
-func (m *PetMutation) OwnerIDs() (ids []int) {
+func (m *PetMutation) OwnerIDs() (ids []uuid.UUID) {
 	if id := m.owner; id != nil {
 		ids = append(ids, *id)
 	}
@@ -2360,9 +2358,9 @@ func (m *PetMutation) ResetFriends() {
 }
 
 // AddFollowedByIDs adds the "followed_by" edge to the User entity by ids.
-func (m *PetMutation) AddFollowedByIDs(ids ...int) {
+func (m *PetMutation) AddFollowedByIDs(ids ...uuid.UUID) {
 	if m.followed_by == nil {
-		m.followed_by = make(map[int]struct{})
+		m.followed_by = make(map[uuid.UUID]struct{})
 	}
 	for i := range ids {
 		m.followed_by[ids[i]] = struct{}{}
@@ -2380,9 +2378,9 @@ func (m *PetMutation) FollowedByCleared() bool {
 }
 
 // RemoveFollowedByIDs removes the "followed_by" edge to the User entity by IDs.
-func (m *PetMutation) RemoveFollowedByIDs(ids ...int) {
+func (m *PetMutation) RemoveFollowedByIDs(ids ...uuid.UUID) {
 	if m.removedfollowed_by == nil {
-		m.removedfollowed_by = make(map[int]struct{})
+		m.removedfollowed_by = make(map[uuid.UUID]struct{})
 	}
 	for i := range ids {
 		delete(m.followed_by, ids[i])
@@ -2391,7 +2389,7 @@ func (m *PetMutation) RemoveFollowedByIDs(ids ...int) {
 }
 
 // RemovedFollowedBy returns the removed IDs of the "followed_by" edge to the User entity.
-func (m *PetMutation) RemovedFollowedByIDs() (ids []int) {
+func (m *PetMutation) RemovedFollowedByIDs() (ids []uuid.UUID) {
 	for id := range m.removedfollowed_by {
 		ids = append(ids, id)
 	}
@@ -2399,7 +2397,7 @@ func (m *PetMutation) RemovedFollowedByIDs() (ids []int) {
 }
 
 // FollowedByIDs returns the "followed_by" edge IDs in the mutation.
-func (m *PetMutation) FollowedByIDs() (ids []int) {
+func (m *PetMutation) FollowedByIDs() (ids []uuid.UUID) {
 	for id := range m.followed_by {
 		ids = append(ids, id)
 	}
@@ -2783,8 +2781,8 @@ type SettingsMutation struct {
 	updated_at    *time.Time
 	global_banner *string
 	clearedFields map[string]struct{}
-	admins        map[int]struct{}
-	removedadmins map[int]struct{}
+	admins        map[uuid.UUID]struct{}
+	removedadmins map[uuid.UUID]struct{}
 	clearedadmins bool
 	done          bool
 	oldValue      func(context.Context) (*Settings, error)
@@ -3011,9 +3009,9 @@ func (m *SettingsMutation) ResetGlobalBanner() {
 }
 
 // AddAdminIDs adds the "admins" edge to the User entity by ids.
-func (m *SettingsMutation) AddAdminIDs(ids ...int) {
+func (m *SettingsMutation) AddAdminIDs(ids ...uuid.UUID) {
 	if m.admins == nil {
-		m.admins = make(map[int]struct{})
+		m.admins = make(map[uuid.UUID]struct{})
 	}
 	for i := range ids {
 		m.admins[ids[i]] = struct{}{}
@@ -3031,9 +3029,9 @@ func (m *SettingsMutation) AdminsCleared() bool {
 }
 
 // RemoveAdminIDs removes the "admins" edge to the User entity by IDs.
-func (m *SettingsMutation) RemoveAdminIDs(ids ...int) {
+func (m *SettingsMutation) RemoveAdminIDs(ids ...uuid.UUID) {
 	if m.removedadmins == nil {
-		m.removedadmins = make(map[int]struct{})
+		m.removedadmins = make(map[uuid.UUID]struct{})
 	}
 	for i := range ids {
 		delete(m.admins, ids[i])
@@ -3042,7 +3040,7 @@ func (m *SettingsMutation) RemoveAdminIDs(ids ...int) {
 }
 
 // RemovedAdmins returns the removed IDs of the "admins" edge to the User entity.
-func (m *SettingsMutation) RemovedAdminsIDs() (ids []int) {
+func (m *SettingsMutation) RemovedAdminsIDs() (ids []uuid.UUID) {
 	for id := range m.removedadmins {
 		ids = append(ids, id)
 	}
@@ -3050,7 +3048,7 @@ func (m *SettingsMutation) RemovedAdminsIDs() (ids []int) {
 }
 
 // AdminsIDs returns the "admins" edge IDs in the mutation.
-func (m *SettingsMutation) AdminsIDs() (ids []int) {
+func (m *SettingsMutation) AdminsIDs() (ids []uuid.UUID) {
 	for id := range m.admins {
 		ids = append(ids, id)
 	}
@@ -3653,7 +3651,7 @@ type UserMutation struct {
 	config
 	op                   Op
 	typ                  string
-	id                   *int
+	id                   *uuid.UUID
 	created_at           *time.Time
 	updated_at           *time.Time
 	name                 *string
@@ -3672,8 +3670,8 @@ type UserMutation struct {
 	followed_pets        map[int]struct{}
 	removedfollowed_pets map[int]struct{}
 	clearedfollowed_pets bool
-	friends              map[int]struct{}
-	removedfriends       map[int]struct{}
+	friends              map[uuid.UUID]struct{}
+	removedfriends       map[uuid.UUID]struct{}
 	clearedfriends       bool
 	friendships          map[int]struct{}
 	removedfriendships   map[int]struct{}
@@ -3703,7 +3701,7 @@ func newUserMutation(c config, op Op, opts ...userOption) *UserMutation {
 }
 
 // withUserID sets the ID field of the mutation.
-func withUserID(id int) userOption {
+func withUserID(id uuid.UUID) userOption {
 	return func(m *UserMutation) {
 		var (
 			err   error
@@ -3755,13 +3753,13 @@ func (m UserMutation) Tx() (*Tx, error) {
 
 // SetID sets the value of the id field. Note that this
 // operation is only accepted on creation of User entities.
-func (m *UserMutation) SetID(id int) {
+func (m *UserMutation) SetID(id uuid.UUID) {
 	m.id = &id
 }
 
 // ID returns the ID value in the mutation. Note that the ID is only available
 // if it was provided to the builder or after it was returned from the database.
-func (m *UserMutation) ID() (id int, exists bool) {
+func (m *UserMutation) ID() (id uuid.UUID, exists bool) {
 	if m.id == nil {
 		return
 	}
@@ -3772,12 +3770,12 @@ func (m *UserMutation) ID() (id int, exists bool) {
 // That means, if the mutation is applied within a transaction with an isolation level such
 // as sql.LevelSerializable, the returned ids match the ids of the rows that will be updated
 // or updated by the mutation.
-func (m *UserMutation) IDs(ctx context.Context) ([]int, error) {
+func (m *UserMutation) IDs(ctx context.Context) ([]uuid.UUID, error) {
 	switch {
 	case m.op.Is(OpUpdateOne | OpDeleteOne):
 		id, exists := m.ID()
 		if exists {
-			return []int{id}, nil
+			return []uuid.UUID{id}, nil
 		}
 		fallthrough
 	case m.op.Is(OpUpdate | OpDelete):
@@ -4357,9 +4355,9 @@ func (m *UserMutation) ResetFollowedPets() {
 }
 
 // AddFriendIDs adds the "friends" edge to the User entity by ids.
-func (m *UserMutation) AddFriendIDs(ids ...int) {
+func (m *UserMutation) AddFriendIDs(ids ...uuid.UUID) {
 	if m.friends == nil {
-		m.friends = make(map[int]struct{})
+		m.friends = make(map[uuid.UUID]struct{})
 	}
 	for i := range ids {
 		m.friends[ids[i]] = struct{}{}
@@ -4377,9 +4375,9 @@ func (m *UserMutation) FriendsCleared() bool {
 }
 
 // RemoveFriendIDs removes the "friends" edge to the User entity by IDs.
-func (m *UserMutation) RemoveFriendIDs(ids ...int) {
+func (m *UserMutation) RemoveFriendIDs(ids ...uuid.UUID) {
 	if m.removedfriends == nil {
-		m.removedfriends = make(map[int]struct{})
+		m.removedfriends = make(map[uuid.UUID]struct{})
 	}
 	for i := range ids {
 		delete(m.friends, ids[i])
@@ -4388,7 +4386,7 @@ func (m *UserMutation) RemoveFriendIDs(ids ...int) {
 }
 
 // RemovedFriends returns the removed IDs of the "friends" edge to the User entity.
-func (m *UserMutation) RemovedFriendsIDs() (ids []int) {
+func (m *UserMutation) RemovedFriendsIDs() (ids []uuid.UUID) {
 	for id := range m.removedfriends {
 		ids = append(ids, id)
 	}
@@ -4396,7 +4394,7 @@ func (m *UserMutation) RemovedFriendsIDs() (ids []int) {
 }
 
 // FriendsIDs returns the "friends" edge IDs in the mutation.
-func (m *UserMutation) FriendsIDs() (ids []int) {
+func (m *UserMutation) FriendsIDs() (ids []uuid.UUID) {
 	for id := range m.friends {
 		ids = append(ids, id)
 	}

--- a/_examples/kitchensink/internal/database/ent/pet.go
+++ b/_examples/kitchensink/internal/database/ent/pet.go
@@ -9,6 +9,7 @@ import (
 
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/pet"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/user"
 )
@@ -29,7 +30,7 @@ type Pet struct {
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the PetQuery when eager-loading is set.
 	Edges        PetEdges `json:"edges"`
-	user_pets    *int
+	user_pets    *uuid.UUID
 	selectValues sql.SelectValues
 }
 
@@ -109,7 +110,7 @@ func (*Pet) scanValues(columns []string) ([]any, error) {
 		case pet.FieldName, pet.FieldType:
 			values[i] = new(sql.NullString)
 		case pet.ForeignKeys[0]: // user_pets
-			values[i] = new(sql.NullInt64)
+			values[i] = &sql.NullScanner{S: new(uuid.UUID)}
 		default:
 			values[i] = new(sql.UnknownType)
 		}
@@ -158,11 +159,11 @@ func (pe *Pet) assignValues(columns []string, values []any) error {
 				pe.Type = pet.Type(value.String)
 			}
 		case pet.ForeignKeys[0]:
-			if value, ok := values[i].(*sql.NullInt64); !ok {
-				return fmt.Errorf("unexpected type %T for edge-field user_pets", value)
+			if value, ok := values[i].(*sql.NullScanner); !ok {
+				return fmt.Errorf("unexpected type %T for field user_pets", values[i])
 			} else if value.Valid {
-				pe.user_pets = new(int)
-				*pe.user_pets = int(value.Int64)
+				pe.user_pets = new(uuid.UUID)
+				*pe.user_pets = *value.S.(*uuid.UUID)
 			}
 		default:
 			pe.selectValues.Set(columns[i], values[i])

--- a/_examples/kitchensink/internal/database/ent/pet_create.go
+++ b/_examples/kitchensink/internal/database/ent/pet_create.go
@@ -9,6 +9,7 @@ import (
 
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/category"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/pet"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/user"
@@ -67,13 +68,13 @@ func (pc *PetCreate) AddCategories(c ...*Category) *PetCreate {
 }
 
 // SetOwnerID sets the "owner" edge to the User entity by ID.
-func (pc *PetCreate) SetOwnerID(id int) *PetCreate {
+func (pc *PetCreate) SetOwnerID(id uuid.UUID) *PetCreate {
 	pc.mutation.SetOwnerID(id)
 	return pc
 }
 
 // SetNillableOwnerID sets the "owner" edge to the User entity by ID if the given value is not nil.
-func (pc *PetCreate) SetNillableOwnerID(id *int) *PetCreate {
+func (pc *PetCreate) SetNillableOwnerID(id *uuid.UUID) *PetCreate {
 	if id != nil {
 		pc = pc.SetOwnerID(*id)
 	}
@@ -101,14 +102,14 @@ func (pc *PetCreate) AddFriends(p ...*Pet) *PetCreate {
 }
 
 // AddFollowedByIDs adds the "followed_by" edge to the User entity by IDs.
-func (pc *PetCreate) AddFollowedByIDs(ids ...int) *PetCreate {
+func (pc *PetCreate) AddFollowedByIDs(ids ...uuid.UUID) *PetCreate {
 	pc.mutation.AddFollowedByIDs(ids...)
 	return pc
 }
 
 // AddFollowedBy adds the "followed_by" edges to the User entity.
 func (pc *PetCreate) AddFollowedBy(u ...*User) *PetCreate {
-	ids := make([]int, len(u))
+	ids := make([]uuid.UUID, len(u))
 	for i := range u {
 		ids[i] = u[i].ID
 	}
@@ -240,7 +241,7 @@ func (pc *PetCreate) createSpec() (*Pet, *sqlgraph.CreateSpec) {
 			Columns: []string{pet.OwnerColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {
@@ -273,7 +274,7 @@ func (pc *PetCreate) createSpec() (*Pet, *sqlgraph.CreateSpec) {
 			Columns: pet.FollowedByPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {

--- a/_examples/kitchensink/internal/database/ent/pet_query.go
+++ b/_examples/kitchensink/internal/database/ent/pet_query.go
@@ -12,6 +12,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/category"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/follows"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/pet"
@@ -646,8 +647,8 @@ func (pq *PetQuery) loadCategories(ctx context.Context, query *CategoryQuery, no
 	return nil
 }
 func (pq *PetQuery) loadOwner(ctx context.Context, query *UserQuery, nodes []*Pet, init func(*Pet), assign func(*Pet, *User)) error {
-	ids := make([]int, 0, len(nodes))
-	nodeids := make(map[int][]*Pet)
+	ids := make([]uuid.UUID, 0, len(nodes))
+	nodeids := make(map[uuid.UUID][]*Pet)
 	for i := range nodes {
 		if nodes[i].user_pets == nil {
 			continue
@@ -741,7 +742,7 @@ func (pq *PetQuery) loadFriends(ctx context.Context, query *PetQuery, nodes []*P
 func (pq *PetQuery) loadFollowedBy(ctx context.Context, query *UserQuery, nodes []*Pet, init func(*Pet), assign func(*Pet, *User)) error {
 	edgeIDs := make([]driver.Value, len(nodes))
 	byID := make(map[int]*Pet)
-	nids := make(map[int]map[*Pet]struct{})
+	nids := make(map[uuid.UUID]map[*Pet]struct{})
 	for i, node := range nodes {
 		edgeIDs[i] = node.ID
 		byID[node.ID] = node
@@ -774,7 +775,7 @@ func (pq *PetQuery) loadFollowedBy(ctx context.Context, query *UserQuery, nodes 
 			}
 			spec.Assign = func(columns []string, values []any) error {
 				outValue := int(values[0].(*sql.NullInt64).Int64)
-				inValue := int(values[1].(*sql.NullInt64).Int64)
+				inValue := *values[1].(*uuid.UUID)
 				if nids[inValue] == nil {
 					nids[inValue] = map[*Pet]struct{}{byID[outValue]: {}}
 					return assign(columns[1:], values[1:])

--- a/_examples/kitchensink/internal/database/ent/pet_update.go
+++ b/_examples/kitchensink/internal/database/ent/pet_update.go
@@ -11,6 +11,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/dialect/sql/sqljson"
 	"entgo.io/ent/schema/field"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/category"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/pet"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/predicate"
@@ -113,13 +114,13 @@ func (pu *PetUpdate) AddCategories(c ...*Category) *PetUpdate {
 }
 
 // SetOwnerID sets the "owner" edge to the User entity by ID.
-func (pu *PetUpdate) SetOwnerID(id int) *PetUpdate {
+func (pu *PetUpdate) SetOwnerID(id uuid.UUID) *PetUpdate {
 	pu.mutation.SetOwnerID(id)
 	return pu
 }
 
 // SetNillableOwnerID sets the "owner" edge to the User entity by ID if the given value is not nil.
-func (pu *PetUpdate) SetNillableOwnerID(id *int) *PetUpdate {
+func (pu *PetUpdate) SetNillableOwnerID(id *uuid.UUID) *PetUpdate {
 	if id != nil {
 		pu = pu.SetOwnerID(*id)
 	}
@@ -147,14 +148,14 @@ func (pu *PetUpdate) AddFriends(p ...*Pet) *PetUpdate {
 }
 
 // AddFollowedByIDs adds the "followed_by" edge to the User entity by IDs.
-func (pu *PetUpdate) AddFollowedByIDs(ids ...int) *PetUpdate {
+func (pu *PetUpdate) AddFollowedByIDs(ids ...uuid.UUID) *PetUpdate {
 	pu.mutation.AddFollowedByIDs(ids...)
 	return pu
 }
 
 // AddFollowedBy adds the "followed_by" edges to the User entity.
 func (pu *PetUpdate) AddFollowedBy(u ...*User) *PetUpdate {
-	ids := make([]int, len(u))
+	ids := make([]uuid.UUID, len(u))
 	for i := range u {
 		ids[i] = u[i].ID
 	}
@@ -221,14 +222,14 @@ func (pu *PetUpdate) ClearFollowedBy() *PetUpdate {
 }
 
 // RemoveFollowedByIDs removes the "followed_by" edge to User entities by IDs.
-func (pu *PetUpdate) RemoveFollowedByIDs(ids ...int) *PetUpdate {
+func (pu *PetUpdate) RemoveFollowedByIDs(ids ...uuid.UUID) *PetUpdate {
 	pu.mutation.RemoveFollowedByIDs(ids...)
 	return pu
 }
 
 // RemoveFollowedBy removes "followed_by" edges to User entities.
 func (pu *PetUpdate) RemoveFollowedBy(u ...*User) *PetUpdate {
-	ids := make([]int, len(u))
+	ids := make([]uuid.UUID, len(u))
 	for i := range u {
 		ids[i] = u[i].ID
 	}
@@ -365,7 +366,7 @@ func (pu *PetUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Columns: []string{pet.OwnerColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
@@ -378,7 +379,7 @@ func (pu *PetUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Columns: []string{pet.OwnerColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {
@@ -439,7 +440,7 @@ func (pu *PetUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Columns: pet.FollowedByPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		createE := &FollowsCreate{config: pu.config, mutation: newFollowsMutation(pu.config, OpCreate)}
@@ -456,7 +457,7 @@ func (pu *PetUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Columns: pet.FollowedByPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {
@@ -476,7 +477,7 @@ func (pu *PetUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Columns: pet.FollowedByPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {
@@ -591,13 +592,13 @@ func (puo *PetUpdateOne) AddCategories(c ...*Category) *PetUpdateOne {
 }
 
 // SetOwnerID sets the "owner" edge to the User entity by ID.
-func (puo *PetUpdateOne) SetOwnerID(id int) *PetUpdateOne {
+func (puo *PetUpdateOne) SetOwnerID(id uuid.UUID) *PetUpdateOne {
 	puo.mutation.SetOwnerID(id)
 	return puo
 }
 
 // SetNillableOwnerID sets the "owner" edge to the User entity by ID if the given value is not nil.
-func (puo *PetUpdateOne) SetNillableOwnerID(id *int) *PetUpdateOne {
+func (puo *PetUpdateOne) SetNillableOwnerID(id *uuid.UUID) *PetUpdateOne {
 	if id != nil {
 		puo = puo.SetOwnerID(*id)
 	}
@@ -625,14 +626,14 @@ func (puo *PetUpdateOne) AddFriends(p ...*Pet) *PetUpdateOne {
 }
 
 // AddFollowedByIDs adds the "followed_by" edge to the User entity by IDs.
-func (puo *PetUpdateOne) AddFollowedByIDs(ids ...int) *PetUpdateOne {
+func (puo *PetUpdateOne) AddFollowedByIDs(ids ...uuid.UUID) *PetUpdateOne {
 	puo.mutation.AddFollowedByIDs(ids...)
 	return puo
 }
 
 // AddFollowedBy adds the "followed_by" edges to the User entity.
 func (puo *PetUpdateOne) AddFollowedBy(u ...*User) *PetUpdateOne {
-	ids := make([]int, len(u))
+	ids := make([]uuid.UUID, len(u))
 	for i := range u {
 		ids[i] = u[i].ID
 	}
@@ -699,14 +700,14 @@ func (puo *PetUpdateOne) ClearFollowedBy() *PetUpdateOne {
 }
 
 // RemoveFollowedByIDs removes the "followed_by" edge to User entities by IDs.
-func (puo *PetUpdateOne) RemoveFollowedByIDs(ids ...int) *PetUpdateOne {
+func (puo *PetUpdateOne) RemoveFollowedByIDs(ids ...uuid.UUID) *PetUpdateOne {
 	puo.mutation.RemoveFollowedByIDs(ids...)
 	return puo
 }
 
 // RemoveFollowedBy removes "followed_by" edges to User entities.
 func (puo *PetUpdateOne) RemoveFollowedBy(u ...*User) *PetUpdateOne {
-	ids := make([]int, len(u))
+	ids := make([]uuid.UUID, len(u))
 	for i := range u {
 		ids[i] = u[i].ID
 	}
@@ -873,7 +874,7 @@ func (puo *PetUpdateOne) sqlSave(ctx context.Context) (_node *Pet, err error) {
 			Columns: []string{pet.OwnerColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
@@ -886,7 +887,7 @@ func (puo *PetUpdateOne) sqlSave(ctx context.Context) (_node *Pet, err error) {
 			Columns: []string{pet.OwnerColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {
@@ -947,7 +948,7 @@ func (puo *PetUpdateOne) sqlSave(ctx context.Context) (_node *Pet, err error) {
 			Columns: pet.FollowedByPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		createE := &FollowsCreate{config: puo.config, mutation: newFollowsMutation(puo.config, OpCreate)}
@@ -964,7 +965,7 @@ func (puo *PetUpdateOne) sqlSave(ctx context.Context) (_node *Pet, err error) {
 			Columns: pet.FollowedByPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {
@@ -984,7 +985,7 @@ func (puo *PetUpdateOne) sqlSave(ctx context.Context) (_node *Pet, err error) {
 			Columns: pet.FollowedByPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {

--- a/_examples/kitchensink/internal/database/ent/rest/create.go
+++ b/_examples/kitchensink/internal/database/ent/rest/create.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	github "github.com/google/go-github/v66/github"
+	uuid "github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/category"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/follows"
@@ -54,8 +55,8 @@ func (c *CreateCategoryParams) Exec(ctx context.Context, builder *ent.CategoryCr
 
 // CreateFollowParams defines parameters for creating a Follow via a POST request.
 type CreateFollowParams struct {
-	UserID int `json:"user_id"`
-	PetID  int `json:"pet_id"`
+	UserID uuid.UUID `json:"user_id"`
+	PetID  int       `json:"pet_id"`
 }
 
 func (c *CreateFollowParams) ApplyInputs(builder *ent.FollowsCreate) *ent.FollowsCreate {
@@ -82,8 +83,8 @@ func (c *CreateFollowParams) Exec(ctx context.Context, builder *ent.FollowsCreat
 // CreateFriendshipParams defines parameters for creating a Friendship via a POST request.
 type CreateFriendshipParams struct {
 	CreatedAt *time.Time `json:"created_at"`
-	UserID    int        `json:"user_id"`
-	FriendID  int        `json:"friend_id"`
+	UserID    uuid.UUID  `json:"user_id"`
+	FriendID  uuid.UUID  `json:"friend_id"`
 }
 
 func (c *CreateFriendshipParams) ApplyInputs(builder *ent.FriendshipCreate) *ent.FriendshipCreate {
@@ -115,11 +116,11 @@ type CreatePetParams struct {
 	// Categories that the pet belongs to.
 	Categories []int `json:"categories,omitempty"`
 	// The user that owns the pet.
-	Owner *int `json:"owner,omitempty"`
+	Owner *uuid.UUID `json:"owner,omitempty"`
 	// Pets that this pet is friends with.
 	Friends []int `json:"friends,omitempty"`
 	// Users that this pet is followed by.
-	FollowedBy []int `json:"followed_by,omitempty"`
+	FollowedBy []uuid.UUID `json:"followed_by,omitempty"`
 }
 
 func (c *CreatePetParams) ApplyInputs(builder *ent.PetCreate) *ent.PetCreate {
@@ -154,7 +155,7 @@ type CreateSettingParams struct {
 	// Global banner text to apply to the frontend.
 	GlobalBanner *string `json:"global_banner,omitempty"`
 	// Administrators for the platform.
-	Admins []int `json:"admins,omitempty"`
+	Admins []uuid.UUID `json:"admins,omitempty"`
 }
 
 func (c *CreateSettingParams) ApplyInputs(builder *ent.SettingsCreate) *ent.SettingsCreate {
@@ -200,8 +201,8 @@ type CreateUserParams struct {
 	// Pets that the user is following.
 	FollowedPets []int `json:"followed_pets,omitempty"`
 	// Friends of the user.
-	Friends     []int `json:"friends,omitempty"`
-	Friendships []int `json:"friendships,omitempty"`
+	Friends     []uuid.UUID `json:"friends,omitempty"`
+	Friendships []int       `json:"friendships,omitempty"`
 }
 
 func (c *CreateUserParams) ApplyInputs(builder *ent.UserCreate) *ent.UserCreate {

--- a/_examples/kitchensink/internal/database/ent/rest/create.go
+++ b/_examples/kitchensink/internal/database/ent/rest/create.go
@@ -179,6 +179,7 @@ func (c *CreateSettingParams) Exec(ctx context.Context, builder *ent.SettingsCre
 
 // CreateUserParams defines parameters for creating a User via a POST request.
 type CreateUserParams struct {
+	ID *uuid.UUID `json:"id"`
 	// Name of the user.
 	Name string `json:"name"`
 	// Type of object being defined (user or system which is for internal usecases).
@@ -206,6 +207,9 @@ type CreateUserParams struct {
 }
 
 func (c *CreateUserParams) ApplyInputs(builder *ent.UserCreate) *ent.UserCreate {
+	if c.ID != nil {
+		builder.SetID(*c.ID)
+	}
 	builder.SetName(c.Name)
 	if c.Type != nil {
 		builder.SetType(*c.Type)

--- a/_examples/kitchensink/internal/database/ent/rest/list.go
+++ b/_examples/kitchensink/internal/database/ent/rest/list.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"entgo.io/ent/dialect/sql"
+	uuid "github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/category"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/friendship"
@@ -356,21 +357,21 @@ type ListFriendshipParams struct {
 	// Filters field "id" to be not within the provided values.
 	FriendshipIDNotIn []int `form:"id.notIn,omitempty" json:"friendship_id_not_in,omitempty"`
 	// Filters field "user_id" to be equal to the provided value.
-	FriendshipUserIDEQ *int `form:"userID.eq,omitempty" json:"friendship_user_ideq,omitempty"`
+	FriendshipUserIDEQ *uuid.UUID `form:"userID.eq,omitempty" json:"friendship_user_ideq,omitempty"`
 	// Filters field "user_id" to be not equal to the provided value.
-	FriendshipUserIDNEQ *int `form:"userID.neq,omitempty" json:"friendship_user_idneq,omitempty"`
+	FriendshipUserIDNEQ *uuid.UUID `form:"userID.neq,omitempty" json:"friendship_user_idneq,omitempty"`
 	// Filters field "user_id" to be within the provided values.
-	FriendshipUserIDIn []int `form:"userID.in,omitempty" json:"friendship_user_id_in,omitempty"`
+	FriendshipUserIDIn []uuid.UUID `form:"userID.in,omitempty" json:"friendship_user_id_in,omitempty"`
 	// Filters field "user_id" to be not within the provided values.
-	FriendshipUserIDNotIn []int `form:"userID.notIn,omitempty" json:"friendship_user_id_not_in,omitempty"`
+	FriendshipUserIDNotIn []uuid.UUID `form:"userID.notIn,omitempty" json:"friendship_user_id_not_in,omitempty"`
 	// Filters field "friend_id" to be equal to the provided value.
-	FriendshipFriendIDEQ *int `form:"friendID.eq,omitempty" json:"friendship_friend_ideq,omitempty"`
+	FriendshipFriendIDEQ *uuid.UUID `form:"friendID.eq,omitempty" json:"friendship_friend_ideq,omitempty"`
 	// Filters field "friend_id" to be not equal to the provided value.
-	FriendshipFriendIDNEQ *int `form:"friendID.neq,omitempty" json:"friendship_friend_idneq,omitempty"`
+	FriendshipFriendIDNEQ *uuid.UUID `form:"friendID.neq,omitempty" json:"friendship_friend_idneq,omitempty"`
 	// Filters field "friend_id" to be within the provided values.
-	FriendshipFriendIDIn []int `form:"friendID.in,omitempty" json:"friendship_friend_id_in,omitempty"`
+	FriendshipFriendIDIn []uuid.UUID `form:"friendID.in,omitempty" json:"friendship_friend_id_in,omitempty"`
 	// Filters field "friend_id" to be not within the provided values.
-	FriendshipFriendIDNotIn []int `form:"friendID.notIn,omitempty" json:"friendship_friend_id_not_in,omitempty"`
+	FriendshipFriendIDNotIn []uuid.UUID `form:"friendID.notIn,omitempty" json:"friendship_friend_id_not_in,omitempty"`
 	// If true, only return entities that have a user edge.
 	EdgeHasUser *bool `form:"has.user,omitempty" json:"edge_has_user,omitempty"`
 	// Filters field "created_at" to be greater than the provided value.
@@ -863,13 +864,13 @@ type ListPetParams struct {
 	// If true, only return entities that have a owner edge.
 	EdgeHasOwner *bool `form:"has.owner,omitempty" json:"edge_has_owner,omitempty"`
 	// Filters field "id" to be equal to the provided value.
-	EdgeOwnerIDEQ *int `form:"owner.id.eq,omitempty" json:"edge_owner_ideq,omitempty"`
+	EdgeOwnerIDEQ *uuid.UUID `form:"owner.id.eq,omitempty" json:"edge_owner_ideq,omitempty"`
 	// Filters field "id" to be not equal to the provided value.
-	EdgeOwnerIDNEQ *int `form:"owner.id.neq,omitempty" json:"edge_owner_idneq,omitempty"`
+	EdgeOwnerIDNEQ *uuid.UUID `form:"owner.id.neq,omitempty" json:"edge_owner_idneq,omitempty"`
 	// Filters field "id" to be within the provided values.
-	EdgeOwnerIDIn []int `form:"owner.id.in,omitempty" json:"edge_owner_id_in,omitempty"`
+	EdgeOwnerIDIn []uuid.UUID `form:"owner.id.in,omitempty" json:"edge_owner_id_in,omitempty"`
 	// Filters field "id" to be not within the provided values.
-	EdgeOwnerIDNotIn []int `form:"owner.id.notIn,omitempty" json:"edge_owner_id_not_in,omitempty"`
+	EdgeOwnerIDNotIn []uuid.UUID `form:"owner.id.notIn,omitempty" json:"edge_owner_id_not_in,omitempty"`
 	// Filters field "created_at" to be greater than the provided value.
 	EdgeOwnerCreatedAtGT *time.Time `form:"owner.createdAt.gt,omitempty" json:"edge_owner_created_at_gt,omitempty"`
 	// Filters field "created_at" to be less than the provided value.
@@ -985,13 +986,13 @@ type ListPetParams struct {
 	// If true, only return entities that have a followed_by edge.
 	EdgeHasFollowedBy *bool `form:"has.followedBy,omitempty" json:"edge_has_followed_by,omitempty"`
 	// Filters field "id" to be equal to the provided value.
-	EdgeFollowedByIDEQ *int `form:"followedBy.id.eq,omitempty" json:"edge_followed_by_ideq,omitempty"`
+	EdgeFollowedByIDEQ *uuid.UUID `form:"followedBy.id.eq,omitempty" json:"edge_followed_by_ideq,omitempty"`
 	// Filters field "id" to be not equal to the provided value.
-	EdgeFollowedByIDNEQ *int `form:"followedBy.id.neq,omitempty" json:"edge_followed_by_idneq,omitempty"`
+	EdgeFollowedByIDNEQ *uuid.UUID `form:"followedBy.id.neq,omitempty" json:"edge_followed_by_idneq,omitempty"`
 	// Filters field "id" to be within the provided values.
-	EdgeFollowedByIDIn []int `form:"followedBy.id.in,omitempty" json:"edge_followed_by_id_in,omitempty"`
+	EdgeFollowedByIDIn []uuid.UUID `form:"followedBy.id.in,omitempty" json:"edge_followed_by_id_in,omitempty"`
 	// Filters field "id" to be not within the provided values.
-	EdgeFollowedByIDNotIn []int `form:"followedBy.id.notIn,omitempty" json:"edge_followed_by_id_not_in,omitempty"`
+	EdgeFollowedByIDNotIn []uuid.UUID `form:"followedBy.id.notIn,omitempty" json:"edge_followed_by_id_not_in,omitempty"`
 	// Filters field "created_at" to be greater than the provided value.
 	EdgeFollowedByCreatedAtGT *time.Time `form:"followedBy.createdAt.gt,omitempty" json:"edge_followed_by_created_at_gt,omitempty"`
 	// Filters field "created_at" to be less than the provided value.
@@ -1620,13 +1621,13 @@ type ListUserParams struct {
 	Filtered[predicate.User]
 
 	// Filters field "id" to be equal to the provided value.
-	UserIDEQ *int `form:"id.eq,omitempty" json:"user_ideq,omitempty"`
+	UserIDEQ *uuid.UUID `form:"id.eq,omitempty" json:"user_ideq,omitempty"`
 	// Filters field "id" to be not equal to the provided value.
-	UserIDNEQ *int `form:"id.neq,omitempty" json:"user_idneq,omitempty"`
+	UserIDNEQ *uuid.UUID `form:"id.neq,omitempty" json:"user_idneq,omitempty"`
 	// Filters field "id" to be within the provided values.
-	UserIDIn []int `form:"id.in,omitempty" json:"user_id_in,omitempty"`
+	UserIDIn []uuid.UUID `form:"id.in,omitempty" json:"user_id_in,omitempty"`
 	// Filters field "id" to be not within the provided values.
-	UserIDNotIn []int `form:"id.notIn,omitempty" json:"user_id_not_in,omitempty"`
+	UserIDNotIn []uuid.UUID `form:"id.notIn,omitempty" json:"user_id_not_in,omitempty"`
 	// Filters field "created_at" to be greater than the provided value.
 	UserCreatedAtGT *time.Time `form:"createdAt.gt,omitempty" json:"user_created_at_gt,omitempty"`
 	// Filters field "created_at" to be less than the provided value.
@@ -1792,13 +1793,13 @@ type ListUserParams struct {
 	// If true, only return entities that have a friend edge.
 	EdgeHasFriend *bool `form:"has.friend,omitempty" json:"edge_has_friend,omitempty"`
 	// Filters field "id" to be equal to the provided value.
-	EdgeFriendIDEQ *int `form:"friend.id.eq,omitempty" json:"edge_friend_ideq,omitempty"`
+	EdgeFriendIDEQ *uuid.UUID `form:"friend.id.eq,omitempty" json:"edge_friend_ideq,omitempty"`
 	// Filters field "id" to be not equal to the provided value.
-	EdgeFriendIDNEQ *int `form:"friend.id.neq,omitempty" json:"edge_friend_idneq,omitempty"`
+	EdgeFriendIDNEQ *uuid.UUID `form:"friend.id.neq,omitempty" json:"edge_friend_idneq,omitempty"`
 	// Filters field "id" to be within the provided values.
-	EdgeFriendIDIn []int `form:"friend.id.in,omitempty" json:"edge_friend_id_in,omitempty"`
+	EdgeFriendIDIn []uuid.UUID `form:"friend.id.in,omitempty" json:"edge_friend_id_in,omitempty"`
 	// Filters field "id" to be not within the provided values.
-	EdgeFriendIDNotIn []int `form:"friend.id.notIn,omitempty" json:"edge_friend_id_not_in,omitempty"`
+	EdgeFriendIDNotIn []uuid.UUID `form:"friend.id.notIn,omitempty" json:"edge_friend_id_not_in,omitempty"`
 	// Filters field "created_at" to be greater than the provided value.
 	EdgeFriendCreatedAtGT *time.Time `form:"friend.createdAt.gt,omitempty" json:"edge_friend_created_at_gt,omitempty"`
 	// Filters field "created_at" to be less than the provided value.
@@ -1874,21 +1875,21 @@ type ListUserParams struct {
 	// Filters field "id" to be not within the provided values.
 	EdgeFriendshipIDNotIn []int `form:"friendship.id.notIn,omitempty" json:"edge_friendship_id_not_in,omitempty"`
 	// Filters field "user_id" to be equal to the provided value.
-	EdgeFriendshipUserIDEQ *int `form:"friendship.userID.eq,omitempty" json:"edge_friendship_user_ideq,omitempty"`
+	EdgeFriendshipUserIDEQ *uuid.UUID `form:"friendship.userID.eq,omitempty" json:"edge_friendship_user_ideq,omitempty"`
 	// Filters field "user_id" to be not equal to the provided value.
-	EdgeFriendshipUserIDNEQ *int `form:"friendship.userID.neq,omitempty" json:"edge_friendship_user_idneq,omitempty"`
+	EdgeFriendshipUserIDNEQ *uuid.UUID `form:"friendship.userID.neq,omitempty" json:"edge_friendship_user_idneq,omitempty"`
 	// Filters field "user_id" to be within the provided values.
-	EdgeFriendshipUserIDIn []int `form:"friendship.userID.in,omitempty" json:"edge_friendship_user_id_in,omitempty"`
+	EdgeFriendshipUserIDIn []uuid.UUID `form:"friendship.userID.in,omitempty" json:"edge_friendship_user_id_in,omitempty"`
 	// Filters field "user_id" to be not within the provided values.
-	EdgeFriendshipUserIDNotIn []int `form:"friendship.userID.notIn,omitempty" json:"edge_friendship_user_id_not_in,omitempty"`
+	EdgeFriendshipUserIDNotIn []uuid.UUID `form:"friendship.userID.notIn,omitempty" json:"edge_friendship_user_id_not_in,omitempty"`
 	// Filters field "friend_id" to be equal to the provided value.
-	EdgeFriendshipFriendIDEQ *int `form:"friendship.friendID.eq,omitempty" json:"edge_friendship_friend_ideq,omitempty"`
+	EdgeFriendshipFriendIDEQ *uuid.UUID `form:"friendship.friendID.eq,omitempty" json:"edge_friendship_friend_ideq,omitempty"`
 	// Filters field "friend_id" to be not equal to the provided value.
-	EdgeFriendshipFriendIDNEQ *int `form:"friendship.friendID.neq,omitempty" json:"edge_friendship_friend_idneq,omitempty"`
+	EdgeFriendshipFriendIDNEQ *uuid.UUID `form:"friendship.friendID.neq,omitempty" json:"edge_friendship_friend_idneq,omitempty"`
 	// Filters field "friend_id" to be within the provided values.
-	EdgeFriendshipFriendIDIn []int `form:"friendship.friendID.in,omitempty" json:"edge_friendship_friend_id_in,omitempty"`
+	EdgeFriendshipFriendIDIn []uuid.UUID `form:"friendship.friendID.in,omitempty" json:"edge_friendship_friend_id_in,omitempty"`
 	// Filters field "friend_id" to be not within the provided values.
-	EdgeFriendshipFriendIDNotIn []int `form:"friendship.friendID.notIn,omitempty" json:"edge_friendship_friend_id_not_in,omitempty"`
+	EdgeFriendshipFriendIDNotIn []uuid.UUID `form:"friendship.friendID.notIn,omitempty" json:"edge_friendship_friend_id_not_in,omitempty"`
 
 	// Field "search.eq" filters across multiple fields (case insensitive): name, description, email.
 	UserFilterGroupSearchEQ *string `form:"search.eq,omitempty" json:"user_filter_group_search_eq,omitempty"`

--- a/_examples/kitchensink/internal/database/ent/rest/openapi.json
+++ b/_examples/kitchensink/internal/database/ent/rest/openapi.json
@@ -7643,7 +7643,8 @@
                         "format": "date-time"
                     },
                     "user_id": {
-                        "type": "integer"
+                        "type": "string",
+                        "format": "uuid"
                     },
                     "pet_id": {
                         "type": "integer"
@@ -7660,7 +7661,8 @@
                 "type": "object",
                 "properties": {
                     "user_id": {
-                        "type": "integer"
+                        "type": "string",
+                        "format": "uuid"
                     },
                     "pet_id": {
                         "type": "integer"
@@ -7754,10 +7756,12 @@
                         "format": "date-time"
                     },
                     "user_id": {
-                        "type": "integer"
+                        "type": "string",
+                        "format": "uuid"
                     },
                     "friend_id": {
-                        "type": "integer"
+                        "type": "string",
+                        "format": "uuid"
                     }
                 },
                 "required": [
@@ -7776,10 +7780,12 @@
                         "format": "date-time"
                     },
                     "user_id": {
-                        "type": "integer"
+                        "type": "string",
+                        "format": "uuid"
                     },
                     "friend_id": {
-                        "type": "integer"
+                        "type": "string",
+                        "format": "uuid"
                     }
                 },
                 "required": [
@@ -7840,10 +7846,12 @@
                         "format": "date-time"
                     },
                     "user_id": {
-                        "type": "integer"
+                        "type": "string",
+                        "format": "uuid"
                     },
                     "friend_id": {
-                        "type": "integer"
+                        "type": "string",
+                        "format": "uuid"
                     }
                 }
             },
@@ -7949,7 +7957,8 @@
                         }
                     },
                     "owner": {
-                        "type": "integer"
+                        "type": "string",
+                        "format": "uuid"
                     },
                     "friends": {
                         "type": "array",
@@ -7960,7 +7969,8 @@
                     "followed_by": {
                         "type": "array",
                         "items": {
-                            "type": "integer"
+                            "type": "string",
+                            "format": "uuid"
                         }
                     }
                 },
@@ -8102,7 +8112,8 @@
                         }
                     },
                     "owner": {
-                        "type": "integer"
+                        "type": "string",
+                        "format": "uuid"
                     },
                     "add_friends": {
                         "type": "array",
@@ -8119,13 +8130,15 @@
                     "add_followed_by": {
                         "type": "array",
                         "items": {
-                            "type": "integer"
+                            "type": "string",
+                            "format": "uuid"
                         }
                     },
                     "remove_followed_by": {
                         "type": "array",
                         "items": {
-                            "type": "integer"
+                            "type": "string",
+                            "format": "uuid"
                         }
                     }
                 }
@@ -8246,13 +8259,15 @@
                     "add_admins": {
                         "type": "array",
                         "items": {
-                            "type": "integer"
+                            "type": "string",
+                            "format": "uuid"
                         }
                     },
                     "remove_admins": {
                         "type": "array",
                         "items": {
-                            "type": "integer"
+                            "type": "string",
+                            "format": "uuid"
                         }
                     }
                 }
@@ -8263,7 +8278,8 @@
                 "properties": {
                     "id": {
                         "description": "The ID of the User entity.",
-                        "type": "integer"
+                        "type": "string",
+                        "format": "uuid"
                     },
                     "created_at": {
                         "description": "Time in which the resource was initially created.",
@@ -8386,7 +8402,8 @@
                     "friends": {
                         "type": "array",
                         "items": {
-                            "type": "integer"
+                            "type": "string",
+                            "format": "uuid"
                         }
                     },
                     "friendships": {
@@ -8471,8 +8488,6 @@
                     "following.count",
                     "friends.count",
                     "friendships.count",
-                    "friendships.friend_id.sum",
-                    "friendships.user_id.sum",
                     "id",
                     "name",
                     "pets.age.sum",
@@ -8565,13 +8580,15 @@
                     "add_friends": {
                         "type": "array",
                         "items": {
-                            "type": "integer"
+                            "type": "string",
+                            "format": "uuid"
                         }
                     },
                     "remove_friends": {
                         "type": "array",
                         "items": {
-                            "type": "integer"
+                            "type": "string",
+                            "format": "uuid"
                         }
                     },
                     "add_friendships": {
@@ -9027,7 +9044,7 @@
                 "in": "query",
                 "description": "Filters field \"id\" to be equal to the provided value.",
                 "schema": {
-                    "type": "integer"
+                    "type": "string"
                 }
             },
             "EdgeFollowedByIDIn": {
@@ -9037,7 +9054,7 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "type": "string"
                     }
                 }
             },
@@ -9046,7 +9063,7 @@
                 "in": "query",
                 "description": "Filters field \"id\" to be not equal to the provided value.",
                 "schema": {
-                    "type": "integer"
+                    "type": "string"
                 }
             },
             "EdgeFollowedByIDNotIn": {
@@ -9056,7 +9073,7 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "type": "string"
                     }
                 }
             },
@@ -9604,7 +9621,7 @@
                 "in": "query",
                 "description": "Filters field \"id\" to be equal to the provided value.",
                 "schema": {
-                    "type": "integer"
+                    "type": "string"
                 }
             },
             "EdgeFriendIDIn": {
@@ -9614,7 +9631,7 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "type": "string"
                     }
                 }
             },
@@ -9623,7 +9640,7 @@
                 "in": "query",
                 "description": "Filters field \"id\" to be not equal to the provided value.",
                 "schema": {
-                    "type": "integer"
+                    "type": "string"
                 }
             },
             "EdgeFriendIDNotIn": {
@@ -9633,7 +9650,7 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "type": "string"
                     }
                 }
             },
@@ -9785,7 +9802,7 @@
                 "in": "query",
                 "description": "Filters field \"friend_id\" to be equal to the provided value.",
                 "schema": {
-                    "type": "integer"
+                    "type": "string"
                 }
             },
             "EdgeFriendshipFriendIDIn": {
@@ -9795,7 +9812,7 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "type": "string"
                     }
                 }
             },
@@ -9804,7 +9821,7 @@
                 "in": "query",
                 "description": "Filters field \"friend_id\" to be not equal to the provided value.",
                 "schema": {
-                    "type": "integer"
+                    "type": "string"
                 }
             },
             "EdgeFriendshipFriendIDNotIn": {
@@ -9814,7 +9831,7 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "type": "string"
                     }
                 }
             },
@@ -9861,7 +9878,7 @@
                 "in": "query",
                 "description": "Filters field \"user_id\" to be equal to the provided value.",
                 "schema": {
-                    "type": "integer"
+                    "type": "string"
                 }
             },
             "EdgeFriendshipUserIDIn": {
@@ -9871,7 +9888,7 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "type": "string"
                     }
                 }
             },
@@ -9880,7 +9897,7 @@
                 "in": "query",
                 "description": "Filters field \"user_id\" to be not equal to the provided value.",
                 "schema": {
-                    "type": "integer"
+                    "type": "string"
                 }
             },
             "EdgeFriendshipUserIDNotIn": {
@@ -9890,7 +9907,7 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "type": "string"
                     }
                 }
             },
@@ -10105,7 +10122,7 @@
                 "in": "query",
                 "description": "Filters field \"id\" to be equal to the provided value.",
                 "schema": {
-                    "type": "integer"
+                    "type": "string"
                 }
             },
             "EdgeOwnerIDIn": {
@@ -10115,7 +10132,7 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "type": "string"
                     }
                 }
             },
@@ -10124,7 +10141,7 @@
                 "in": "query",
                 "description": "Filters field \"id\" to be not equal to the provided value.",
                 "schema": {
-                    "type": "integer"
+                    "type": "string"
                 }
             },
             "EdgeOwnerIDNotIn": {
@@ -10134,7 +10151,7 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "type": "string"
                     }
                 }
             },
@@ -10768,7 +10785,7 @@
                 "in": "query",
                 "description": "Filters field \"friend_id\" to be equal to the provided value.",
                 "schema": {
-                    "type": "integer"
+                    "type": "string"
                 }
             },
             "FriendshipFriendIDIn": {
@@ -10778,7 +10795,7 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "type": "string"
                     }
                 }
             },
@@ -10787,7 +10804,7 @@
                 "in": "query",
                 "description": "Filters field \"friend_id\" to be not equal to the provided value.",
                 "schema": {
-                    "type": "integer"
+                    "type": "string"
                 }
             },
             "FriendshipFriendIDNotIn": {
@@ -10797,7 +10814,7 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "type": "string"
                     }
                 }
             },
@@ -10853,7 +10870,7 @@
                 "in": "query",
                 "description": "Filters field \"user_id\" to be equal to the provided value.",
                 "schema": {
-                    "type": "integer"
+                    "type": "string"
                 }
             },
             "FriendshipUserIDIn": {
@@ -10863,7 +10880,7 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "type": "string"
                     }
                 }
             },
@@ -10872,7 +10889,7 @@
                 "in": "query",
                 "description": "Filters field \"user_id\" to be not equal to the provided value.",
                 "schema": {
-                    "type": "integer"
+                    "type": "string"
                 }
             },
             "FriendshipUserIDNotIn": {
@@ -10882,7 +10899,7 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "type": "string"
                     }
                 }
             },
@@ -11432,7 +11449,8 @@
                 "description": "The ID of the User to act upon.",
                 "required": true,
                 "schema": {
-                    "type": "integer"
+                    "type": "string",
+                    "format": "uuid"
                 }
             },
             "UserIDEQ": {
@@ -11440,7 +11458,7 @@
                 "in": "query",
                 "description": "Filters field \"id\" to be equal to the provided value.",
                 "schema": {
-                    "type": "integer"
+                    "type": "string"
                 }
             },
             "UserIDIn": {
@@ -11450,7 +11468,7 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "type": "string"
                     }
                 }
             },
@@ -11459,7 +11477,7 @@
                 "in": "query",
                 "description": "Filters field \"id\" to be not equal to the provided value.",
                 "schema": {
-                    "type": "integer"
+                    "type": "string"
                 }
             },
             "UserIDNotIn": {
@@ -11469,7 +11487,7 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "type": "string"
                     }
                 }
             },

--- a/_examples/kitchensink/internal/database/ent/rest/openapi.json
+++ b/_examples/kitchensink/internal/database/ent/rest/openapi.json
@@ -8766,7 +8766,8 @@
                 "in": "query",
                 "description": "Filters field \"created_at\" to be greater than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "CategoryCreatedAtLT": {
@@ -8774,7 +8775,8 @@
                 "in": "query",
                 "description": "Filters field \"created_at\" to be less than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "CategoryID": {
@@ -8829,7 +8831,8 @@
                 "in": "query",
                 "description": "Filters field \"updated_at\" to be greater than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "CategoryUpdatedAtLT": {
@@ -8837,7 +8840,8 @@
                 "in": "query",
                 "description": "Filters field \"updated_at\" to be less than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "EdgeCategoryCreatedAtGT": {
@@ -8845,7 +8849,8 @@
                 "in": "query",
                 "description": "Filters field \"created_at\" to be greater than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "EdgeCategoryCreatedAtLT": {
@@ -8853,7 +8858,8 @@
                 "in": "query",
                 "description": "Filters field \"created_at\" to be less than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "EdgeCategoryIDEQ": {
@@ -8899,7 +8905,8 @@
                 "in": "query",
                 "description": "Filters field \"updated_at\" to be greater than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "EdgeCategoryUpdatedAtLT": {
@@ -8907,7 +8914,8 @@
                 "in": "query",
                 "description": "Filters field \"updated_at\" to be less than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "EdgeFollowedByCreatedAtGT": {
@@ -8915,7 +8923,8 @@
                 "in": "query",
                 "description": "Filters field \"created_at\" to be greater than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "EdgeFollowedByCreatedAtLT": {
@@ -8923,7 +8932,8 @@
                 "in": "query",
                 "description": "Filters field \"created_at\" to be less than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "EdgeFollowedByDescriptionContains": {
@@ -9049,7 +9059,8 @@
                 "in": "query",
                 "description": "Filters field \"id\" to be equal to the provided value.",
                 "schema": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "uuid"
                 }
             },
             "EdgeFollowedByIDIn": {
@@ -9059,7 +9070,8 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "format": "uuid"
                     }
                 }
             },
@@ -9068,7 +9080,8 @@
                 "in": "query",
                 "description": "Filters field \"id\" to be not equal to the provided value.",
                 "schema": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "uuid"
                 }
             },
             "EdgeFollowedByIDNotIn": {
@@ -9078,7 +9091,8 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "format": "uuid"
                     }
                 }
             },
@@ -9203,7 +9217,8 @@
                 "in": "query",
                 "description": "Filters field \"updated_at\" to be greater than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "EdgeFollowedByUpdatedAtLT": {
@@ -9211,7 +9226,8 @@
                 "in": "query",
                 "description": "Filters field \"updated_at\" to be less than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "EdgeFollowedPetAgeEQ": {
@@ -9492,7 +9508,8 @@
                 "in": "query",
                 "description": "Filters field \"created_at\" to be greater than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "EdgeFriendCreatedAtLT": {
@@ -9500,7 +9517,8 @@
                 "in": "query",
                 "description": "Filters field \"created_at\" to be less than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "EdgeFriendDescriptionContains": {
@@ -9626,7 +9644,8 @@
                 "in": "query",
                 "description": "Filters field \"id\" to be equal to the provided value.",
                 "schema": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "uuid"
                 }
             },
             "EdgeFriendIDIn": {
@@ -9636,7 +9655,8 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "format": "uuid"
                     }
                 }
             },
@@ -9645,7 +9665,8 @@
                 "in": "query",
                 "description": "Filters field \"id\" to be not equal to the provided value.",
                 "schema": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "uuid"
                 }
             },
             "EdgeFriendIDNotIn": {
@@ -9655,7 +9676,8 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "format": "uuid"
                     }
                 }
             },
@@ -9791,7 +9813,8 @@
                 "in": "query",
                 "description": "Filters field \"updated_at\" to be greater than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "EdgeFriendUpdatedAtLT": {
@@ -9799,7 +9822,8 @@
                 "in": "query",
                 "description": "Filters field \"updated_at\" to be less than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "EdgeFriendshipFriendIDEQ": {
@@ -9807,7 +9831,8 @@
                 "in": "query",
                 "description": "Filters field \"friend_id\" to be equal to the provided value.",
                 "schema": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "uuid"
                 }
             },
             "EdgeFriendshipFriendIDIn": {
@@ -9817,7 +9842,8 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "format": "uuid"
                     }
                 }
             },
@@ -9826,7 +9852,8 @@
                 "in": "query",
                 "description": "Filters field \"friend_id\" to be not equal to the provided value.",
                 "schema": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "uuid"
                 }
             },
             "EdgeFriendshipFriendIDNotIn": {
@@ -9836,7 +9863,8 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "format": "uuid"
                     }
                 }
             },
@@ -9883,7 +9911,8 @@
                 "in": "query",
                 "description": "Filters field \"user_id\" to be equal to the provided value.",
                 "schema": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "uuid"
                 }
             },
             "EdgeFriendshipUserIDIn": {
@@ -9893,7 +9922,8 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "format": "uuid"
                     }
                 }
             },
@@ -9902,7 +9932,8 @@
                 "in": "query",
                 "description": "Filters field \"user_id\" to be not equal to the provided value.",
                 "schema": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "uuid"
                 }
             },
             "EdgeFriendshipUserIDNotIn": {
@@ -9912,7 +9943,8 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "format": "uuid"
                     }
                 }
             },
@@ -9993,7 +10025,8 @@
                 "in": "query",
                 "description": "Filters field \"created_at\" to be greater than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "EdgeOwnerCreatedAtLT": {
@@ -10001,7 +10034,8 @@
                 "in": "query",
                 "description": "Filters field \"created_at\" to be less than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "EdgeOwnerDescriptionContains": {
@@ -10127,7 +10161,8 @@
                 "in": "query",
                 "description": "Filters field \"id\" to be equal to the provided value.",
                 "schema": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "uuid"
                 }
             },
             "EdgeOwnerIDIn": {
@@ -10137,7 +10172,8 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "format": "uuid"
                     }
                 }
             },
@@ -10146,7 +10182,8 @@
                 "in": "query",
                 "description": "Filters field \"id\" to be not equal to the provided value.",
                 "schema": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "uuid"
                 }
             },
             "EdgeOwnerIDNotIn": {
@@ -10156,7 +10193,8 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "format": "uuid"
                     }
                 }
             },
@@ -10281,7 +10319,8 @@
                 "in": "query",
                 "description": "Filters field \"updated_at\" to be greater than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "EdgeOwnerUpdatedAtLT": {
@@ -10289,7 +10328,8 @@
                 "in": "query",
                 "description": "Filters field \"updated_at\" to be less than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "EdgePetAgeEQ": {
@@ -10516,7 +10556,8 @@
                 "in": "query",
                 "description": "Filters field \"created_at\" to be greater than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "EdgeUserCreatedAtLT": {
@@ -10524,7 +10565,8 @@
                 "in": "query",
                 "description": "Filters field \"created_at\" to be less than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "EdgeUserDescriptionContains": {
@@ -10766,7 +10808,8 @@
                 "in": "query",
                 "description": "Filters field \"updated_at\" to be greater than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "EdgeUserUpdatedAtLT": {
@@ -10774,7 +10817,8 @@
                 "in": "query",
                 "description": "Filters field \"updated_at\" to be less than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "FilterOperation": {
@@ -10790,7 +10834,8 @@
                 "in": "query",
                 "description": "Filters field \"friend_id\" to be equal to the provided value.",
                 "schema": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "uuid"
                 }
             },
             "FriendshipFriendIDIn": {
@@ -10800,7 +10845,8 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "format": "uuid"
                     }
                 }
             },
@@ -10809,7 +10855,8 @@
                 "in": "query",
                 "description": "Filters field \"friend_id\" to be not equal to the provided value.",
                 "schema": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "uuid"
                 }
             },
             "FriendshipFriendIDNotIn": {
@@ -10819,7 +10866,8 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "format": "uuid"
                     }
                 }
             },
@@ -10875,7 +10923,8 @@
                 "in": "query",
                 "description": "Filters field \"user_id\" to be equal to the provided value.",
                 "schema": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "uuid"
                 }
             },
             "FriendshipUserIDIn": {
@@ -10885,7 +10934,8 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "format": "uuid"
                     }
                 }
             },
@@ -10894,7 +10944,8 @@
                 "in": "query",
                 "description": "Filters field \"user_id\" to be not equal to the provided value.",
                 "schema": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "uuid"
                 }
             },
             "FriendshipUserIDNotIn": {
@@ -10904,7 +10955,8 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "format": "uuid"
                     }
                 }
             },
@@ -11168,7 +11220,8 @@
                 "in": "query",
                 "description": "Filters field \"created_at\" to be greater than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "SettingsCreatedAtLT": {
@@ -11176,7 +11229,8 @@
                 "in": "query",
                 "description": "Filters field \"created_at\" to be less than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "SettingsIDEQ": {
@@ -11222,7 +11276,8 @@
                 "in": "query",
                 "description": "Filters field \"updated_at\" to be greater than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "SettingsUpdatedAtLT": {
@@ -11230,7 +11285,8 @@
                 "in": "query",
                 "description": "Filters field \"updated_at\" to be less than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "UserCreatedAtGT": {
@@ -11238,7 +11294,8 @@
                 "in": "query",
                 "description": "Filters field \"created_at\" to be greater than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "UserCreatedAtLT": {
@@ -11246,7 +11303,8 @@
                 "in": "query",
                 "description": "Filters field \"created_at\" to be less than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "UserDescriptionContains": {
@@ -11463,7 +11521,8 @@
                 "in": "query",
                 "description": "Filters field \"id\" to be equal to the provided value.",
                 "schema": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "uuid"
                 }
             },
             "UserIDIn": {
@@ -11473,7 +11532,8 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "format": "uuid"
                     }
                 }
             },
@@ -11482,7 +11542,8 @@
                 "in": "query",
                 "description": "Filters field \"id\" to be not equal to the provided value.",
                 "schema": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "uuid"
                 }
             },
             "UserIDNotIn": {
@@ -11492,7 +11553,8 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "format": "uuid"
                     }
                 }
             },
@@ -11617,7 +11679,8 @@
                 "in": "query",
                 "description": "Filters field \"updated_at\" to be greater than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "UserUpdatedAtLT": {
@@ -11625,7 +11688,8 @@
                 "in": "query",
                 "description": "Filters field \"updated_at\" to be less than the provided value.",
                 "schema": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "date-time"
                 }
             },
             "X-Request-Id": {

--- a/_examples/kitchensink/internal/database/ent/rest/openapi.json
+++ b/_examples/kitchensink/internal/database/ent/rest/openapi.json
@@ -8344,6 +8344,11 @@
                 "description": "A single User entity and the fields that can be created/updated.",
                 "type": "object",
                 "properties": {
+                    "id": {
+                        "description": "The ID of the User entity. If not provided, one will be generated.",
+                        "type": "string",
+                        "format": "uuid"
+                    },
                     "name": {
                         "description": "Name of the user.",
                         "type": "string"

--- a/_examples/kitchensink/internal/database/ent/rest/openapi.json
+++ b/_examples/kitchensink/internal/database/ent/rest/openapi.json
@@ -11127,7 +11127,7 @@
             "PrettyResponse": {
                 "name": "pretty",
                 "in": "query",
-                "description": "If set to true, any JSON response will be indented. Not recommended for best performance.",
+                "description": "If set to true, any JSON response will be indented.",
                 "schema": {
                     "type": "boolean"
                 }

--- a/_examples/kitchensink/internal/database/ent/rest/sorting.go
+++ b/_examples/kitchensink/internal/database/ent/rest/sorting.go
@@ -168,8 +168,6 @@ var (
 			"following.count",
 			"friends.count",
 			"friendships.count",
-			"friendships.friend_id.sum",
-			"friendships.user_id.sum",
 			"id",
 			"name",
 			"pets.age.sum",

--- a/_examples/kitchensink/internal/database/ent/rest/update.go
+++ b/_examples/kitchensink/internal/database/ent/rest/update.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	github "github.com/google/go-github/v66/github"
+	uuid "github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/category"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/friendship"
@@ -65,8 +66,8 @@ func (c *UpdateCategoryParams) Exec(ctx context.Context, builder *ent.CategoryUp
 // UpdateFriendshipParams defines parameters for updating a Friendship via a PATCH request.
 type UpdateFriendshipParams struct {
 	CreatedAt Option[time.Time] `json:"created_at"`
-	UserID    Option[int]       `json:"user_id"`
-	FriendID  Option[int]       `json:"friend_id"`
+	UserID    Option[uuid.UUID] `json:"user_id"`
+	FriendID  Option[uuid.UUID] `json:"friend_id"`
 }
 
 func (u *UpdateFriendshipParams) ApplyInputs(builder *ent.FriendshipUpdateOne) *ent.FriendshipUpdateOne {
@@ -107,15 +108,15 @@ type UpdatePetParams struct {
 	// Categories that the pet belongs to.
 	Categories Option[[]int] `json:"categories,omitempty"`
 	// The user that owns the pet.
-	Owner Option[*int] `json:"owner,omitempty"`
+	Owner Option[*uuid.UUID] `json:"owner,omitempty"`
 	// Pets that this pet is friends with.
 	AddFriends Option[[]int] `json:"add_friends,omitempty"`
 	// Pets that this pet is friends with.
 	RemoveFriends Option[[]int] `json:"remove_friends,omitempty"`
 	// Users that this pet is followed by.
-	AddFollowedBy Option[[]int] `json:"add_followed_by,omitempty"`
+	AddFollowedBy Option[[]uuid.UUID] `json:"add_followed_by,omitempty"`
 	// Users that this pet is followed by.
-	RemoveFollowedBy Option[[]int] `json:"remove_followed_by,omitempty"`
+	RemoveFollowedBy Option[[]uuid.UUID] `json:"remove_followed_by,omitempty"`
 }
 
 func (u *UpdatePetParams) ApplyInputs(builder *ent.PetUpdateOne) *ent.PetUpdateOne {
@@ -183,9 +184,9 @@ type UpdateSettingParams struct {
 	// Global banner text to apply to the frontend.
 	GlobalBanner Option[*string] `json:"global_banner,omitempty"`
 	// Administrators for the platform.
-	AddAdmins Option[[]int] `json:"add_admins,omitempty"`
+	AddAdmins Option[[]uuid.UUID] `json:"add_admins,omitempty"`
 	// Administrators for the platform.
-	RemoveAdmins Option[[]int] `json:"remove_admins,omitempty"`
+	RemoveAdmins Option[[]uuid.UUID] `json:"remove_admins,omitempty"`
 }
 
 func (u *UpdateSettingParams) ApplyInputs(builder *ent.SettingsUpdateOne) *ent.SettingsUpdateOne {
@@ -245,11 +246,11 @@ type UpdateUserParams struct {
 	// Pets that the user is following.
 	RemoveFollowedPets Option[[]int] `json:"remove_followed_pets,omitempty"`
 	// Friends of the user.
-	AddFriends Option[[]int] `json:"add_friends,omitempty"`
+	AddFriends Option[[]uuid.UUID] `json:"add_friends,omitempty"`
 	// Friends of the user.
-	RemoveFriends     Option[[]int] `json:"remove_friends,omitempty"`
-	AddFriendships    Option[[]int] `json:"add_friendships,omitempty"`
-	RemoveFriendships Option[[]int] `json:"remove_friendships,omitempty"`
+	RemoveFriends     Option[[]uuid.UUID] `json:"remove_friends,omitempty"`
+	AddFriendships    Option[[]int]       `json:"add_friendships,omitempty"`
+	RemoveFriendships Option[[]int]       `json:"remove_friendships,omitempty"`
 }
 
 func (u *UpdateUserParams) ApplyInputs(builder *ent.UserUpdateOne) *ent.UserUpdateOne {

--- a/_examples/kitchensink/internal/database/ent/runtime.go
+++ b/_examples/kitchensink/internal/database/ent/runtime.go
@@ -5,6 +5,7 @@ package ent
 import (
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/category"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/follows"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/friendship"
@@ -183,4 +184,8 @@ func init() {
 	userDescProfileURL := userFields[9].Descriptor()
 	// user.DefaultProfileURL holds the default value on creation for the profile_url field.
 	user.DefaultProfileURL = userDescProfileURL.Default.(*schema.ExampleValuer)
+	// userDescID is the schema descriptor for id field.
+	userDescID := userFields[0].Descriptor()
+	// user.DefaultID holds the default value on creation for the id field.
+	user.DefaultID = userDescID.Default.(func() uuid.UUID)
 }

--- a/_examples/kitchensink/internal/database/ent/settings_create.go
+++ b/_examples/kitchensink/internal/database/ent/settings_create.go
@@ -10,6 +10,7 @@ import (
 
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/settings"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/user"
 )
@@ -64,14 +65,14 @@ func (sc *SettingsCreate) SetNillableGlobalBanner(s *string) *SettingsCreate {
 }
 
 // AddAdminIDs adds the "admins" edge to the User entity by IDs.
-func (sc *SettingsCreate) AddAdminIDs(ids ...int) *SettingsCreate {
+func (sc *SettingsCreate) AddAdminIDs(ids ...uuid.UUID) *SettingsCreate {
 	sc.mutation.AddAdminIDs(ids...)
 	return sc
 }
 
 // AddAdmins adds the "admins" edges to the User entity.
 func (sc *SettingsCreate) AddAdmins(u ...*User) *SettingsCreate {
-	ids := make([]int, len(u))
+	ids := make([]uuid.UUID, len(u))
 	for i := range u {
 		ids[i] = u[i].ID
 	}
@@ -182,7 +183,7 @@ func (sc *SettingsCreate) createSpec() (*Settings, *sqlgraph.CreateSpec) {
 			Columns: []string{settings.AdminsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {

--- a/_examples/kitchensink/internal/database/ent/settings_update.go
+++ b/_examples/kitchensink/internal/database/ent/settings_update.go
@@ -11,6 +11,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/predicate"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/settings"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/user"
@@ -56,14 +57,14 @@ func (su *SettingsUpdate) ClearGlobalBanner() *SettingsUpdate {
 }
 
 // AddAdminIDs adds the "admins" edge to the User entity by IDs.
-func (su *SettingsUpdate) AddAdminIDs(ids ...int) *SettingsUpdate {
+func (su *SettingsUpdate) AddAdminIDs(ids ...uuid.UUID) *SettingsUpdate {
 	su.mutation.AddAdminIDs(ids...)
 	return su
 }
 
 // AddAdmins adds the "admins" edges to the User entity.
 func (su *SettingsUpdate) AddAdmins(u ...*User) *SettingsUpdate {
-	ids := make([]int, len(u))
+	ids := make([]uuid.UUID, len(u))
 	for i := range u {
 		ids[i] = u[i].ID
 	}
@@ -82,14 +83,14 @@ func (su *SettingsUpdate) ClearAdmins() *SettingsUpdate {
 }
 
 // RemoveAdminIDs removes the "admins" edge to User entities by IDs.
-func (su *SettingsUpdate) RemoveAdminIDs(ids ...int) *SettingsUpdate {
+func (su *SettingsUpdate) RemoveAdminIDs(ids ...uuid.UUID) *SettingsUpdate {
 	su.mutation.RemoveAdminIDs(ids...)
 	return su
 }
 
 // RemoveAdmins removes "admins" edges to User entities.
 func (su *SettingsUpdate) RemoveAdmins(u ...*User) *SettingsUpdate {
-	ids := make([]int, len(u))
+	ids := make([]uuid.UUID, len(u))
 	for i := range u {
 		ids[i] = u[i].ID
 	}
@@ -171,7 +172,7 @@ func (su *SettingsUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Columns: []string{settings.AdminsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
@@ -184,7 +185,7 @@ func (su *SettingsUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Columns: []string{settings.AdminsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {
@@ -200,7 +201,7 @@ func (su *SettingsUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Columns: []string{settings.AdminsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {
@@ -255,14 +256,14 @@ func (suo *SettingsUpdateOne) ClearGlobalBanner() *SettingsUpdateOne {
 }
 
 // AddAdminIDs adds the "admins" edge to the User entity by IDs.
-func (suo *SettingsUpdateOne) AddAdminIDs(ids ...int) *SettingsUpdateOne {
+func (suo *SettingsUpdateOne) AddAdminIDs(ids ...uuid.UUID) *SettingsUpdateOne {
 	suo.mutation.AddAdminIDs(ids...)
 	return suo
 }
 
 // AddAdmins adds the "admins" edges to the User entity.
 func (suo *SettingsUpdateOne) AddAdmins(u ...*User) *SettingsUpdateOne {
-	ids := make([]int, len(u))
+	ids := make([]uuid.UUID, len(u))
 	for i := range u {
 		ids[i] = u[i].ID
 	}
@@ -281,14 +282,14 @@ func (suo *SettingsUpdateOne) ClearAdmins() *SettingsUpdateOne {
 }
 
 // RemoveAdminIDs removes the "admins" edge to User entities by IDs.
-func (suo *SettingsUpdateOne) RemoveAdminIDs(ids ...int) *SettingsUpdateOne {
+func (suo *SettingsUpdateOne) RemoveAdminIDs(ids ...uuid.UUID) *SettingsUpdateOne {
 	suo.mutation.RemoveAdminIDs(ids...)
 	return suo
 }
 
 // RemoveAdmins removes "admins" edges to User entities.
 func (suo *SettingsUpdateOne) RemoveAdmins(u ...*User) *SettingsUpdateOne {
-	ids := make([]int, len(u))
+	ids := make([]uuid.UUID, len(u))
 	for i := range u {
 		ids[i] = u[i].ID
 	}
@@ -400,7 +401,7 @@ func (suo *SettingsUpdateOne) sqlSave(ctx context.Context) (_node *Settings, err
 			Columns: []string{settings.AdminsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
@@ -413,7 +414,7 @@ func (suo *SettingsUpdateOne) sqlSave(ctx context.Context) (_node *Settings, err
 			Columns: []string{settings.AdminsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {
@@ -429,7 +430,7 @@ func (suo *SettingsUpdateOne) sqlSave(ctx context.Context) (_node *Settings, err
 			Columns: []string{settings.AdminsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {

--- a/_examples/kitchensink/internal/database/ent/user.go
+++ b/_examples/kitchensink/internal/database/ent/user.go
@@ -11,6 +11,7 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"github.com/google/go-github/v66/github"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/user"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/schema"
 )
@@ -19,7 +20,7 @@ import (
 type User struct {
 	config `json:"-"`
 	// ID of the ent.
-	ID int `json:"id,omitempty"`
+	ID uuid.UUID `json:"id,omitempty"`
 	// Time in which the resource was initially created.
 	CreatedAt time.Time `json:"created_at"`
 	// Time that the resource was last updated.
@@ -122,12 +123,12 @@ func (*User) scanValues(columns []string) ([]any, error) {
 			values[i] = new(schema.ExampleValuer)
 		case user.FieldEnabled:
 			values[i] = new(sql.NullBool)
-		case user.FieldID:
-			values[i] = new(sql.NullInt64)
 		case user.FieldName, user.FieldType, user.FieldDescription, user.FieldEmail, user.FieldPasswordHashed:
 			values[i] = new(sql.NullString)
 		case user.FieldCreatedAt, user.FieldUpdatedAt:
 			values[i] = new(sql.NullTime)
+		case user.FieldID:
+			values[i] = new(uuid.UUID)
 		case user.ForeignKeys[0]: // settings_admins
 			values[i] = new(sql.NullInt64)
 		default:
@@ -146,11 +147,11 @@ func (u *User) assignValues(columns []string, values []any) error {
 	for i := range columns {
 		switch columns[i] {
 		case user.FieldID:
-			value, ok := values[i].(*sql.NullInt64)
-			if !ok {
-				return fmt.Errorf("unexpected type %T for field id", value)
+			if value, ok := values[i].(*uuid.UUID); !ok {
+				return fmt.Errorf("unexpected type %T for field id", values[i])
+			} else if value != nil {
+				u.ID = *value
 			}
-			u.ID = int(value.Int64)
 		case user.FieldCreatedAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {
 				return fmt.Errorf("unexpected type %T for field created_at", values[i])

--- a/_examples/kitchensink/internal/database/ent/user/user.go
+++ b/_examples/kitchensink/internal/database/ent/user/user.go
@@ -8,6 +8,7 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/schema"
 )
 
@@ -145,6 +146,8 @@ var (
 	PasswordHashedValidator func(string) error
 	// DefaultProfileURL holds the default value on creation for the "profile_url" field.
 	DefaultProfileURL *schema.ExampleValuer
+	// DefaultID holds the default value on creation for the "id" field.
+	DefaultID func() uuid.UUID
 )
 
 // Type defines the type for the "type" enum field.

--- a/_examples/kitchensink/internal/database/ent/user/where.go
+++ b/_examples/kitchensink/internal/database/ent/user/where.go
@@ -7,52 +7,53 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/predicate"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/schema"
 )
 
 // ID filters vertices based on their ID field.
-func ID(id int) predicate.User {
+func ID(id uuid.UUID) predicate.User {
 	return predicate.User(sql.FieldEQ(FieldID, id))
 }
 
 // IDEQ applies the EQ predicate on the ID field.
-func IDEQ(id int) predicate.User {
+func IDEQ(id uuid.UUID) predicate.User {
 	return predicate.User(sql.FieldEQ(FieldID, id))
 }
 
 // IDNEQ applies the NEQ predicate on the ID field.
-func IDNEQ(id int) predicate.User {
+func IDNEQ(id uuid.UUID) predicate.User {
 	return predicate.User(sql.FieldNEQ(FieldID, id))
 }
 
 // IDIn applies the In predicate on the ID field.
-func IDIn(ids ...int) predicate.User {
+func IDIn(ids ...uuid.UUID) predicate.User {
 	return predicate.User(sql.FieldIn(FieldID, ids...))
 }
 
 // IDNotIn applies the NotIn predicate on the ID field.
-func IDNotIn(ids ...int) predicate.User {
+func IDNotIn(ids ...uuid.UUID) predicate.User {
 	return predicate.User(sql.FieldNotIn(FieldID, ids...))
 }
 
 // IDGT applies the GT predicate on the ID field.
-func IDGT(id int) predicate.User {
+func IDGT(id uuid.UUID) predicate.User {
 	return predicate.User(sql.FieldGT(FieldID, id))
 }
 
 // IDGTE applies the GTE predicate on the ID field.
-func IDGTE(id int) predicate.User {
+func IDGTE(id uuid.UUID) predicate.User {
 	return predicate.User(sql.FieldGTE(FieldID, id))
 }
 
 // IDLT applies the LT predicate on the ID field.
-func IDLT(id int) predicate.User {
+func IDLT(id uuid.UUID) predicate.User {
 	return predicate.User(sql.FieldLT(FieldID, id))
 }
 
 // IDLTE applies the LTE predicate on the ID field.
-func IDLTE(id int) predicate.User {
+func IDLTE(id uuid.UUID) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldID, id))
 }
 

--- a/_examples/kitchensink/internal/database/ent/user_create.go
+++ b/_examples/kitchensink/internal/database/ent/user_create.go
@@ -11,6 +11,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/google/go-github/v66/github"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/friendship"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/pet"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/user"
@@ -139,8 +140,16 @@ func (uc *UserCreate) SetProfileURL(sv *schema.ExampleValuer) *UserCreate {
 }
 
 // SetID sets the "id" field.
-func (uc *UserCreate) SetID(i int) *UserCreate {
-	uc.mutation.SetID(i)
+func (uc *UserCreate) SetID(u uuid.UUID) *UserCreate {
+	uc.mutation.SetID(u)
+	return uc
+}
+
+// SetNillableID sets the "id" field if the given value is not nil.
+func (uc *UserCreate) SetNillableID(u *uuid.UUID) *UserCreate {
+	if u != nil {
+		uc.SetID(*u)
+	}
 	return uc
 }
 
@@ -175,14 +184,14 @@ func (uc *UserCreate) AddFollowedPets(p ...*Pet) *UserCreate {
 }
 
 // AddFriendIDs adds the "friends" edge to the User entity by IDs.
-func (uc *UserCreate) AddFriendIDs(ids ...int) *UserCreate {
+func (uc *UserCreate) AddFriendIDs(ids ...uuid.UUID) *UserCreate {
 	uc.mutation.AddFriendIDs(ids...)
 	return uc
 }
 
 // AddFriends adds the "friends" edges to the User entity.
 func (uc *UserCreate) AddFriends(u ...*User) *UserCreate {
-	ids := make([]int, len(u))
+	ids := make([]uuid.UUID, len(u))
 	for i := range u {
 		ids[i] = u[i].ID
 	}
@@ -259,6 +268,10 @@ func (uc *UserCreate) defaults() {
 		v := user.DefaultProfileURL
 		uc.mutation.SetProfileURL(v)
 	}
+	if _, ok := uc.mutation.ID(); !ok {
+		v := user.DefaultID()
+		uc.mutation.SetID(v)
+	}
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -320,9 +333,12 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 		}
 		return nil, err
 	}
-	if _spec.ID.Value != _node.ID {
-		id := _spec.ID.Value.(int64)
-		_node.ID = int(id)
+	if _spec.ID.Value != nil {
+		if id, ok := _spec.ID.Value.(*uuid.UUID); ok {
+			_node.ID = *id
+		} else if err := _node.ID.Scan(_spec.ID.Value); err != nil {
+			return nil, err
+		}
 	}
 	uc.mutation.id = &_node.ID
 	uc.mutation.done = true
@@ -332,11 +348,11 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 func (uc *UserCreate) createSpec() (*User, *sqlgraph.CreateSpec) {
 	var (
 		_node = &User{config: uc.config}
-		_spec = sqlgraph.NewCreateSpec(user.Table, sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt))
+		_spec = sqlgraph.NewCreateSpec(user.Table, sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID))
 	)
 	if id, ok := uc.mutation.ID(); ok {
 		_node.ID = id
-		_spec.ID.Value = id
+		_spec.ID.Value = &id
 	}
 	if value, ok := uc.mutation.CreatedAt(); ok {
 		_spec.SetField(user.FieldCreatedAt, field.TypeTime, value)
@@ -426,7 +442,7 @@ func (uc *UserCreate) createSpec() (*User, *sqlgraph.CreateSpec) {
 			Columns: user.FriendsPrimaryKey,
 			Bidi:    true,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {
@@ -502,10 +518,6 @@ func (ucb *UserCreateBulk) Save(ctx context.Context) ([]*User, error) {
 					return nil, err
 				}
 				mutation.id = &nodes[i].ID
-				if specs[i].ID.Value != nil && nodes[i].ID == 0 {
-					id := specs[i].ID.Value.(int64)
-					nodes[i].ID = int(id)
-				}
 				mutation.done = true
 				return nodes[i], nil
 			})

--- a/_examples/kitchensink/internal/database/ent/user_delete.go
+++ b/_examples/kitchensink/internal/database/ent/user_delete.go
@@ -40,7 +40,7 @@ func (ud *UserDelete) ExecX(ctx context.Context) int {
 }
 
 func (ud *UserDelete) sqlExec(ctx context.Context) (int, error) {
-	_spec := sqlgraph.NewDeleteSpec(user.Table, sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt))
+	_spec := sqlgraph.NewDeleteSpec(user.Table, sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID))
 	if ps := ud.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {

--- a/_examples/kitchensink/internal/database/ent/user_update.go
+++ b/_examples/kitchensink/internal/database/ent/user_update.go
@@ -12,6 +12,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/google/go-github/v66/github"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/friendship"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/pet"
 	"github.com/lrstanley/entrest/_examples/kitchensink/internal/database/ent/predicate"
@@ -201,14 +202,14 @@ func (uu *UserUpdate) AddFollowedPets(p ...*Pet) *UserUpdate {
 }
 
 // AddFriendIDs adds the "friends" edge to the User entity by IDs.
-func (uu *UserUpdate) AddFriendIDs(ids ...int) *UserUpdate {
+func (uu *UserUpdate) AddFriendIDs(ids ...uuid.UUID) *UserUpdate {
 	uu.mutation.AddFriendIDs(ids...)
 	return uu
 }
 
 // AddFriends adds the "friends" edges to the User entity.
 func (uu *UserUpdate) AddFriends(u ...*User) *UserUpdate {
-	ids := make([]int, len(u))
+	ids := make([]uuid.UUID, len(u))
 	for i := range u {
 		ids[i] = u[i].ID
 	}
@@ -284,14 +285,14 @@ func (uu *UserUpdate) ClearFriends() *UserUpdate {
 }
 
 // RemoveFriendIDs removes the "friends" edge to User entities by IDs.
-func (uu *UserUpdate) RemoveFriendIDs(ids ...int) *UserUpdate {
+func (uu *UserUpdate) RemoveFriendIDs(ids ...uuid.UUID) *UserUpdate {
 	uu.mutation.RemoveFriendIDs(ids...)
 	return uu
 }
 
 // RemoveFriends removes "friends" edges to User entities.
 func (uu *UserUpdate) RemoveFriends(u ...*User) *UserUpdate {
-	ids := make([]int, len(u))
+	ids := make([]uuid.UUID, len(u))
 	for i := range u {
 		ids[i] = u[i].ID
 	}
@@ -389,7 +390,7 @@ func (uu *UserUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if err := uu.check(); err != nil {
 		return n, err
 	}
-	_spec := sqlgraph.NewUpdateSpec(user.Table, user.Columns, sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt))
+	_spec := sqlgraph.NewUpdateSpec(user.Table, user.Columns, sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID))
 	if ps := uu.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
@@ -552,7 +553,7 @@ func (uu *UserUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Columns: user.FriendsPrimaryKey,
 			Bidi:    true,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		createE := &FriendshipCreate{config: uu.config, mutation: newFriendshipMutation(uu.config, OpCreate)}
@@ -569,7 +570,7 @@ func (uu *UserUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Columns: user.FriendsPrimaryKey,
 			Bidi:    true,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {
@@ -589,7 +590,7 @@ func (uu *UserUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Columns: user.FriendsPrimaryKey,
 			Bidi:    true,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {
@@ -835,14 +836,14 @@ func (uuo *UserUpdateOne) AddFollowedPets(p ...*Pet) *UserUpdateOne {
 }
 
 // AddFriendIDs adds the "friends" edge to the User entity by IDs.
-func (uuo *UserUpdateOne) AddFriendIDs(ids ...int) *UserUpdateOne {
+func (uuo *UserUpdateOne) AddFriendIDs(ids ...uuid.UUID) *UserUpdateOne {
 	uuo.mutation.AddFriendIDs(ids...)
 	return uuo
 }
 
 // AddFriends adds the "friends" edges to the User entity.
 func (uuo *UserUpdateOne) AddFriends(u ...*User) *UserUpdateOne {
-	ids := make([]int, len(u))
+	ids := make([]uuid.UUID, len(u))
 	for i := range u {
 		ids[i] = u[i].ID
 	}
@@ -918,14 +919,14 @@ func (uuo *UserUpdateOne) ClearFriends() *UserUpdateOne {
 }
 
 // RemoveFriendIDs removes the "friends" edge to User entities by IDs.
-func (uuo *UserUpdateOne) RemoveFriendIDs(ids ...int) *UserUpdateOne {
+func (uuo *UserUpdateOne) RemoveFriendIDs(ids ...uuid.UUID) *UserUpdateOne {
 	uuo.mutation.RemoveFriendIDs(ids...)
 	return uuo
 }
 
 // RemoveFriends removes "friends" edges to User entities.
 func (uuo *UserUpdateOne) RemoveFriends(u ...*User) *UserUpdateOne {
-	ids := make([]int, len(u))
+	ids := make([]uuid.UUID, len(u))
 	for i := range u {
 		ids[i] = u[i].ID
 	}
@@ -1036,7 +1037,7 @@ func (uuo *UserUpdateOne) sqlSave(ctx context.Context) (_node *User, err error) 
 	if err := uuo.check(); err != nil {
 		return _node, err
 	}
-	_spec := sqlgraph.NewUpdateSpec(user.Table, user.Columns, sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt))
+	_spec := sqlgraph.NewUpdateSpec(user.Table, user.Columns, sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID))
 	id, ok := uuo.mutation.ID()
 	if !ok {
 		return nil, &ValidationError{Name: "id", err: errors.New(`ent: missing "User.id" for update`)}
@@ -1216,7 +1217,7 @@ func (uuo *UserUpdateOne) sqlSave(ctx context.Context) (_node *User, err error) 
 			Columns: user.FriendsPrimaryKey,
 			Bidi:    true,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		createE := &FriendshipCreate{config: uuo.config, mutation: newFriendshipMutation(uuo.config, OpCreate)}
@@ -1233,7 +1234,7 @@ func (uuo *UserUpdateOne) sqlSave(ctx context.Context) (_node *User, err error) 
 			Columns: user.FriendsPrimaryKey,
 			Bidi:    true,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {
@@ -1253,7 +1254,7 @@ func (uuo *UserUpdateOne) sqlSave(ctx context.Context) (_node *User, err error) 
 			Columns: user.FriendsPrimaryKey,
 			Bidi:    true,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {

--- a/_examples/kitchensink/internal/database/schema/follows.go
+++ b/_examples/kitchensink/internal/database/schema/follows.go
@@ -12,6 +12,7 @@ import (
 	"entgo.io/ent/schema"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest"
 )
 
@@ -27,7 +28,7 @@ func (Follows) Fields() []ent.Field {
 				entrest.WithSortable(true),
 				entrest.WithReadOnly(true),
 			),
-		field.Int("user_id"),
+		field.UUID("user_id", uuid.Nil),
 		field.Int("pet_id"),
 	}
 }

--- a/_examples/kitchensink/internal/database/schema/friendship.go
+++ b/_examples/kitchensink/internal/database/schema/friendship.go
@@ -11,6 +11,7 @@ import (
 	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest"
 )
 
@@ -22,12 +23,12 @@ func (Friendship) Fields() []ent.Field {
 	return []ent.Field{
 		field.Time("created_at").
 			Default(time.Now),
-		field.Int("user_id").
+		field.UUID("user_id", uuid.Nil).
 			Annotations(
 				entrest.WithSortable(true),
 				entrest.WithFilter(entrest.FilterGroupEqualExact|entrest.FilterGroupArray),
 			),
-		field.Int("friend_id").
+		field.UUID("friend_id", uuid.Nil).
 			Annotations(
 				entrest.WithSortable(true),
 				entrest.WithFilter(entrest.FilterGroupEqualExact|entrest.FilterGroupArray),

--- a/_examples/kitchensink/internal/database/schema/user.go
+++ b/_examples/kitchensink/internal/database/schema/user.go
@@ -143,6 +143,7 @@ func (User) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entrest.WithDefaultSort("name"),
 		entrest.WithDefaultOrder(entrest.OrderAsc),
+		entrest.WithAllowClientIDs(true),
 	}
 }
 

--- a/_examples/kitchensink/internal/database/schema/user.go
+++ b/_examples/kitchensink/internal/database/schema/user.go
@@ -16,6 +16,7 @@ import (
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 	"github.com/google/go-github/v66/github"
+	"github.com/google/uuid"
 	"github.com/lrstanley/entrest"
 	"github.com/ogen-go/ogen"
 )
@@ -26,7 +27,8 @@ type User struct {
 
 func (User) Fields() []ent.Field {
 	return []ent.Field{
-		field.Int("id").
+		field.UUID("id", uuid.Nil).
+			Default(uuid.New).
 			Unique().
 			Immutable().
 			Annotations(

--- a/annotations.go
+++ b/annotations.go
@@ -105,6 +105,7 @@ type Annotation struct {
 	DefaultSort     *string     `json:",omitempty" ent:"schema"`
 	DefaultOrder    *SortOrder  `json:",omitempty" ent:"schema"`
 	Skip            bool        `json:",omitempty" ent:"schema,edge,field"`
+	AllowClientIDs  *bool       `json:",omitempty" ent:"schema"`
 	Operations      []Operation `json:",omitempty" ent:"schema,edge"`
 }
 
@@ -237,6 +238,9 @@ func (a Annotation) Merge(o schema.Annotation) schema.Annotation { // nolint:goc
 		a.DefaultOrder = am.DefaultOrder
 	}
 	a.Skip = a.Skip || am.Skip
+	if am.AllowClientIDs != nil {
+		a.AllowClientIDs = am.AllowClientIDs
+	}
 	a.ReadOnly = a.ReadOnly || am.ReadOnly
 	if len(am.Operations) > 0 {
 		for _, op := range am.Operations {
@@ -413,6 +417,13 @@ func (a *Annotation) GetSkip(config *Config) bool {
 	return a.Skip || len(a.GetOperations(config)) == 0
 }
 
+func (a *Annotation) GetAllowClientIDs(config *Config) bool {
+	if a.AllowClientIDs == nil {
+		return config.AllowClientIDs
+	}
+	return *a.AllowClientIDs
+}
+
 // WithOperationSummary provides a summary for the specified operation. This should be
 // a short summary of what the operation does.
 func WithOperationSummary(op Operation, v string) Annotation {
@@ -579,6 +590,14 @@ func WithDefaultOrder(v SortOrder) Annotation {
 // sensitive isn't set on the field for some reason).
 func WithSkip(v bool) Annotation {
 	return Annotation{Skip: v}
+}
+
+// WithAllowClientIDs sets the schema to allow the client to provide the ID field
+// as part of a CREATE payload. This is beneficial to allow the client to supply
+// UUIDs as primary keys (for idempotency), or when your ID field is a username, for
+// example. This is not required if [Config.AllowClientIDs] is enabled.
+func WithAllowClientIDs(v bool) Annotation {
+	return Annotation{AllowClientIDs: &v}
 }
 
 // WithReadOnly sets the field to be read-only in the REST API. If you want to make

--- a/config.go
+++ b/config.go
@@ -140,9 +140,10 @@ type Config struct {
 	// binary/rest generated library.
 	DisableSpecHandler bool
 
-	// AllowClientIDs, when enabled, allows the built-in "id" field as part of a "Create"
-	// payload for entity creation, allowing the client to supply UUIDs as primary keys
-	// and for idempotency, for example.
+	// AllowClientIDs, when enabled, allows requests to include the "id" field as part of a
+	// CREATE payload for entity creation. This is beneficial to allow the client to supply
+	// UUIDs as primary keys (for idempotency), or when your ID field is a username, for example.
+	// This can be enabled on a per-schema basis with annotations.
 	AllowClientIDs bool
 
 	// DisablePatchJSONTag disables a ent generation hook that patches the JSON tag of all

--- a/config.go
+++ b/config.go
@@ -142,8 +142,8 @@ type Config struct {
 
 	// AllowClientIDs, when enabled, allows the built-in "id" field as part of a "Create"
 	// payload for entity creation, allowing the client to supply UUIDs as primary keys
-	// and for idempotency.
-	AllowClientUUIDs bool
+	// and for idempotency, for example.
+	AllowClientIDs bool
 
 	// DisablePatchJSONTag disables a ent generation hook that patches the JSON tag of all
 	// fields in the schema, removing the usage of omitempty. This helps ensure that fields

--- a/config_test.go
+++ b/config_test.go
@@ -633,6 +633,10 @@ func TestConfig_AllowClientIDs(t *testing.T) {
 		assert.Equal(t, "uuid", r.json(`$.components.schemas.AllTypeCreate.properties.id.format`))
 		assert.Equal(t, "string", r.json(`$.components.parameters.AllTypeID.schema.type`))
 		assert.Equal(t, "uuid", r.json(`$.components.parameters.AllTypeID.schema.format`))
+
+		assert.Equal(t, "string", r.json(`$.components.schemas.User.properties.id.type`))
+		assert.Equal(t, "string", r.json(`$.components.schemas.UserCreate.properties.id.type`))
+		assert.Equal(t, "string", r.json(`$.components.parameters.UserID.schema.type`))
 	})
 
 	t.Run("disabled", func(t *testing.T) {

--- a/config_test.go
+++ b/config_test.go
@@ -642,13 +642,24 @@ func TestConfig_AllowClientIDs(t *testing.T) {
 	t.Run("disabled", func(t *testing.T) {
 		t.Parallel()
 
-		r := mustBuildSpec(t, &Config{AllowClientIDs: false})
+		r := mustBuildSpec(t, &Config{
+			AllowClientIDs: false,
+			PreGenerateHook: func(g *gen.Graph, _ *ogen.Spec) error {
+				injectAnnotations(t, g, "User", WithAllowClientIDs(true))
+				return nil
+			},
+		})
 
 		assert.Equal(t, "string", r.json(`$.components.schemas.AllType.properties.id.type`))
 		assert.Equal(t, "uuid", r.json(`$.components.schemas.AllType.properties.id.format`))
 		assert.Nil(t, r.json(`$.components.schemas.AllTypeCreate.properties.id`))
 		assert.Equal(t, "string", r.json(`$.components.parameters.AllTypeID.schema.type`))
 		assert.Equal(t, "uuid", r.json(`$.components.parameters.AllTypeID.schema.format`))
+
+		// This should still be enabled because of WithAllowClientIDs.
+		assert.Equal(t, "string", r.json(`$.components.schemas.User.properties.id.type`))
+		assert.Equal(t, "string", r.json(`$.components.schemas.UserCreate.properties.id.type`))
+		assert.Equal(t, "string", r.json(`$.components.parameters.UserID.schema.type`))
 	})
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -619,13 +619,13 @@ func TestConfig_GlobalErrorResponses(t *testing.T) {
 	})
 }
 
-func TestConfig_AllowClientUUIDs(t *testing.T) {
+func TestConfig_AllowClientIDs(t *testing.T) {
 	t.Parallel()
 
 	t.Run("enabled", func(t *testing.T) {
 		t.Parallel()
 
-		r := mustBuildSpec(t, &Config{AllowClientUUIDs: true})
+		r := mustBuildSpec(t, &Config{AllowClientIDs: true})
 
 		assert.Equal(t, "string", r.json(`$.components.schemas.AllType.properties.id.type`))
 		assert.Equal(t, "uuid", r.json(`$.components.schemas.AllType.properties.id.format`))
@@ -638,7 +638,7 @@ func TestConfig_AllowClientUUIDs(t *testing.T) {
 	t.Run("disabled", func(t *testing.T) {
 		t.Parallel()
 
-		r := mustBuildSpec(t, &Config{AllowClientUUIDs: false})
+		r := mustBuildSpec(t, &Config{AllowClientIDs: false})
 
 		assert.Equal(t, "string", r.json(`$.components.schemas.AllType.properties.id.type`))
 		assert.Equal(t, "uuid", r.json(`$.components.schemas.AllType.properties.id.format`))

--- a/docs/content/docs/openapi-specs/annotation-reference.mdx
+++ b/docs/content/docs/openapi-specs/annotation-reference.mdx
@@ -31,6 +31,7 @@ Depending on the annotation used, it can only be applied in specific locations, 
 | [WithFilterGroup](#withfiltergroup) | <Usage types={["edge", "field"]} /> | Adds the field to a group of other fields that are filtered together. |
 | [WithSchema](#withschema) | <Usage types={["field"]} /> | Sets the OpenAPI schema for the specified field. |
 | [WithPagination](#withpagination) | <Usage types={["schema", "edge"]} /> | Sets the schema to be paginated in the REST API. |
+| [WithAllowClientIDs](#withallowclientids) | <Usage types={["schema", "edge"]} /> | Sets the schema to allow clients to provide IDs in the CREATE payload. |
 | [WithOperationSummary](#withoperationsummary) | <Usage types={["schema", "edge"]} /> | Provides an OpenAPI summary for the specified operation. |
 | [WithOperationDescription](#withoperationdescription) | <Usage types={["schema", "edge"]} /> | Provides an OpenAPI description for the specified operation. |
 | [WithAdditionalTags](#withadditionaltags) | <Usage types={["schema", "edge"]} /> | Adds additional tags to all operations for this schema/edge. |
@@ -317,6 +318,24 @@ func (Pet) Fields() []ent.Field {
 func (Pet) Annotations() []ent.Annotation {
     return []ent.Annotation{
         entrest.WithPagination(true),
+    }
+}
+```
+
+### `WithAllowClientIDs`
+
+[ [pkg.go.dev](https://pkg.go.dev/github.com/lrstanley/entrest#WithAllowClientIDs) | usage: <Usage types={["schema"]} /> ]
+
+> Sets the schema to allow clients to provide IDs in the CREATE payload. This is beneficial to allow
+> the client to supply UUIDs as primary keys (for idempotency), or when your ID field is a username,
+> for example. This is not required if `Config.AllowClientIDs` is enabled.
+
+##### Example
+
+```go title="internal/database/schema/schema_pet.go" ins={3}
+func (Pet) Annotations() []ent.Annotation {
+    return []ent.Annotation{
+        entrest.WithAllowClientIDs(true),
     }
 }
 ```

--- a/schema.go
+++ b/schema.go
@@ -171,6 +171,9 @@ func GetSchemaType(t *gen.Type, op Operation, edge *gen.Edge) map[string]*ogen.S
 				panic(fmt.Sprintf("failed to generate schema for field %s: %v", t.ID.StructField(), err))
 			}
 			fieldSchema.Description = fmt.Sprintf("The ID of the %s entity.", entityName)
+			if t.ID.Default {
+				fieldSchema.Description += " If not provided, one will be generated."
+			}
 			schema.Properties = append(schema.Properties, *fieldSchema.ToProperty("id"))
 
 			if !t.ID.Default {

--- a/schema.go
+++ b/schema.go
@@ -165,7 +165,7 @@ func GetSchemaType(t *gen.Type, op Operation, edge *gen.Edge) map[string]*ogen.S
 
 		var fieldSchema *ogen.Schema
 
-		if op == OperationCreate && cfg.AllowClientUUIDs && t.ID != nil && t.ID.IsUUID() {
+		if op == OperationCreate && cfg.AllowClientIDs && t.ID != nil {
 			fieldSchema, err = GetSchemaField(t.ID)
 			if err != nil {
 				panic(fmt.Sprintf("failed to generate schema for field %s: %v", t.ID.StructField(), err))

--- a/schema.go
+++ b/schema.go
@@ -165,7 +165,7 @@ func GetSchemaType(t *gen.Type, op Operation, edge *gen.Edge) map[string]*ogen.S
 
 		var fieldSchema *ogen.Schema
 
-		if op == OperationCreate && cfg.AllowClientIDs && t.ID != nil {
+		if op == OperationCreate && ta.GetAllowClientIDs(cfg) && t.ID != nil {
 			fieldSchema, err = GetSchemaField(t.ID)
 			if err != nil {
 				panic(fmt.Sprintf("failed to generate schema for field %s: %v", t.ID.StructField(), err))

--- a/schema_filtering.go
+++ b/schema_filtering.go
@@ -326,6 +326,7 @@ func (f *FilterableFieldOp) Parameter() *ogen.Parameter {
 	schema := &ogen.Schema{
 		Ref:        f.fieldSchema.Ref,
 		Type:       f.fieldSchema.Type,
+		Format:     f.fieldSchema.Format,
 		Items:      f.fieldSchema.Items,
 		Minimum:    f.fieldSchema.Minimum,
 		Maximum:    f.fieldSchema.Maximum,

--- a/spec.go
+++ b/spec.go
@@ -111,7 +111,7 @@ func newBaseSpec(_ *Config) *ogen.Spec {
 				"PrettyResponse": {
 					Name:        "pretty",
 					In:          "query",
-					Description: "If set to true, any JSON response will be indented. Not recommended for best performance.",
+					Description: "If set to true, any JSON response will be indented.",
 					Schema:      ogen.Bool(),
 				},
 				"FilterOperation": {

--- a/templates/create.tmpl
+++ b/templates/create.tmpl
@@ -65,9 +65,9 @@ import (
             {{- else }}
                 {{- template "helper/rest/fields/comment" $e }}
                 {{- if $e.Optional }}
-                    {{ $e.StructField }} {{ if not $e.Unique }}[]{{else }}*{{ end }}{{ $e.Type.IDType.String }} {{ template "helper/rest/edge/tag" (dict "Edge" $e) }}
+                    {{ $e.StructField }} {{ if not $e.Unique }}[]{{else }}*{{ end }}{{ $e.Type.ID.Type }} {{ template "helper/rest/edge/tag" (dict "Edge" $e) }}
                 {{- else }}
-                    {{ $e.StructField }} {{ $e.Type.IDType.String }} {{ template "helper/rest/edge/tag" (dict "Edge" $e) }}
+                    {{ $e.StructField }} {{ $e.Type.ID.Type }} {{ template "helper/rest/edge/tag" (dict "Edge" $e) }}
                 {{- end }}
             {{- end }}
         {{- end }}

--- a/templates/create.tmpl
+++ b/templates/create.tmpl
@@ -16,6 +16,16 @@ import (
 
     // Create{{ $t.Name|zsingular }}Params defines parameters for creating a {{ $t.Name|zsingular }} via a POST request.
     type Create{{ $t.Name|zsingular }}Params struct {
+        {{- /* if we allow client-provided IDs, we need to add the ID field to the params struct */}}
+        {{- if and $.Annotations.RestConfig.AllowClientIDs $t.ID }}
+            {{- template "helper/rest/fields/comment" $t.ID }}
+            {{- if or (hasPrefix $t.ID.Type.Ident "[]") (hasPrefix $t.ID.Type.Ident "*") $t.ID.IsBytes }}
+                {{ $t.ID.StructField }} {{ $t.ID.Type }} {{ template "helper/rest/fields/tag" (dict "Field" $t.ID) }}
+            {{- else }}
+                {{ $t.ID.StructField }} *{{ $t.ID.Type }} {{ template "helper/rest/fields/tag" (dict "Field" $t.ID) }}
+            {{- end }}
+        {{- end }}
+
         {{- range $f := $t.Fields }}
             {{- if or (($f|getAnnotation).GetSkip $.Annotations.RestConfig) $f.Annotations.Rest.ReadOnly }}{{ continue }}{{ end -}}
 
@@ -64,6 +74,12 @@ import (
     }
 
     func (c *Create{{ $t.Name|zsingular }}Params) ApplyInputs(builder *ent.{{ $t.Name }}Create) *ent.{{ $t.Name }}Create {
+        {{- if and $.Annotations.RestConfig.AllowClientIDs $t.ID }}
+            if c.{{ $t.ID.StructField }} != nil {
+                builder.Set{{ $t.ID.StructField }}(*c.{{ $t.ID.StructField }})
+            }
+        {{- end }}
+
         {{- range $f := $t.Fields }}
             {{- if or (($f|getAnnotation).GetSkip $.Annotations.RestConfig) $f.Annotations.Rest.ReadOnly }}{{ continue }}{{ end -}}
 

--- a/templates/create.tmpl
+++ b/templates/create.tmpl
@@ -17,7 +17,7 @@ import (
     // Create{{ $t.Name|zsingular }}Params defines parameters for creating a {{ $t.Name|zsingular }} via a POST request.
     type Create{{ $t.Name|zsingular }}Params struct {
         {{- /* if we allow client-provided IDs, we need to add the ID field to the params struct */}}
-        {{- if and $.Annotations.RestConfig.AllowClientIDs $t.ID }}
+        {{- if and (($t|getAnnotation).GetAllowClientIDs $.Annotations.RestConfig) $t.ID }}
             {{- template "helper/rest/fields/comment" $t.ID }}
             {{- if or (hasPrefix $t.ID.Type.Ident "[]") (hasPrefix $t.ID.Type.Ident "*") $t.ID.IsBytes }}
                 {{ $t.ID.StructField }} {{ $t.ID.Type }} {{ template "helper/rest/fields/tag" (dict "Field" $t.ID) }}
@@ -74,7 +74,7 @@ import (
     }
 
     func (c *Create{{ $t.Name|zsingular }}Params) ApplyInputs(builder *ent.{{ $t.Name }}Create) *ent.{{ $t.Name }}Create {
-        {{- if and $.Annotations.RestConfig.AllowClientIDs $t.ID }}
+        {{- if and (($t|getAnnotation).GetAllowClientIDs $.Annotations.RestConfig) $t.ID }}
             if c.{{ $t.ID.StructField }} != nil {
                 builder.Set{{ $t.ID.StructField }}(*c.{{ $t.ID.StructField }})
             }

--- a/templates/helper/schema-imports.tmpl
+++ b/templates/helper/schema-imports.tmpl
@@ -7,6 +7,9 @@
     {{- range $t := $.Nodes }}
         {{- if (($t|getAnnotation).GetSkip $.Annotations.RestConfig) }}{{ continue }}{{ end }}
         "{{ $.Config.Package }}/{{ $t.Package }}"
+        {{- if and $t.ID $t.ID.Type.PkgPath }}
+            {{ $t.ID.Type.PkgName }} "{{ $t.ID.Type.PkgPath }}"
+        {{- end }}
         {{- range $f := $t.Fields }}
             {{- if $f.Type.PkgPath }}
                 {{ $f.Type.PkgName }} "{{ $f.Type.PkgPath }}"

--- a/templates/helper/server/endpoint.tmpl
+++ b/templates/helper/server/endpoint.tmpl
@@ -5,7 +5,7 @@
 */ -}}
 {{- define "helper/rest/server/endpoint" -}}
     {{- if eq $.Handler "chi" }}
-        r.{{ $.Method|lower|zpascal }}("{{ replace $.Path "{id}" "{id:^[0-9]{1,50}$}" }}", {{ $.Func }})
+        r.{{ $.Method|lower|zpascal }}("{{ $.Path }}", {{ $.Func }})
     {{- else }}
         mux.HandleFunc("{{ $.Method }} {{ $.Path }}", {{ $.Func }})
     {{- end }}

--- a/templates/helper/server/errors.tmpl
+++ b/templates/helper/server/errors.tmpl
@@ -44,4 +44,23 @@
     func IsMethodNotAllowed(err error) bool {
         return errors.Is(err, ErrMethodNotAllowed)
     }
+
+    type ErrInvalidID struct {
+        ID string
+        Err error
+    }
+
+    func (e ErrInvalidID) Error() string {
+        return fmt.Sprintf("invalid ID provided: %q: %v", e.ID, e.Err)
+    }
+
+    func (e ErrInvalidID) Unwrap() error {
+        return e.Err
+    }
+
+    // IsInvalidID returns true if the unwrapped/underlying error is of type ErrInvalidID.
+    func IsInvalidID(err error) bool {
+        var target *ErrInvalidID
+	    return errors.As(err, &target)
+    }
 {{- end }}{{/* end template */}}

--- a/templates/helper/server/req.tmpl
+++ b/templates/helper/server/req.tmpl
@@ -14,11 +14,51 @@
         }
     }
 
+    // resolveID resolves the ID from the request path, and unmarshals it into the provided type.
+    // Only supports string, int, and types that support UnmarshalText, UnmarshalJSON, or UnmarshalBinary
+    // (in that order).
+    func resolveID[T any](r *http.Request) (id T, err error) {
+        value := r.PathValue("id")
+
+        switch any(id).(type) {
+        case string:
+            id = any(value).(T)
+        case int:
+            rid, err := strconv.Atoi(value)
+            if err == nil {
+                id = any(rid).(T)
+            }
+        default:
+            hasUnmarshal := false
+
+            // Check if the underlying type supports UnmarshalText, UnmarshalJSON, or UnmarshalBinary.
+            if u, ok := any(&id).(encoding.TextUnmarshaler); ok {
+                hasUnmarshal = true
+                err = u.UnmarshalText([]byte(value))
+            } else if u, ok := any(&id).(json.Unmarshaler); ok {
+                hasUnmarshal = true
+                err = u.UnmarshalJSON([]byte(value))
+            } else if u, ok := any(&id).(encoding.BinaryUnmarshaler); ok {
+                hasUnmarshal = true
+                err = u.UnmarshalBinary([]byte(value))
+            }
+
+            if !hasUnmarshal {
+                panic(fmt.Sprintf("unsupported ID type (cannot unmarshal): %T", id))
+            }
+        }
+
+        if err != nil {
+            return id, &ErrInvalidID{ID: value, Err: err}
+        }
+        return id, nil
+    }
+
     // ReqID is similar to Req, but also processes an "id" path parameter and provides it to the
     // handler function.
-    func ReqID[Resp any](s *Server, op Operation, fn func(*http.Request, int) (*Resp, error)) http.HandlerFunc {
+    func ReqID[Resp, I any](s *Server, op Operation, fn func(*http.Request, I) (*Resp, error)) http.HandlerFunc {
         return func(w http.ResponseWriter, r *http.Request) {
-            id, err := strconv.Atoi(r.PathValue("id"))
+            id, err := resolveID[I](r)
             if err != nil {
                 handleResponse[Resp](s, w, r, op, nil, err)
                 return
@@ -44,9 +84,9 @@
 
     // ReqIDParam is similar to ReqParam, but also processes an "id" path parameter and request
     // body/query params, and provides it to the handler function.
-    func ReqIDParam[Params, Resp any](s *Server, op Operation, fn func(*http.Request, int, *Params) (*Resp, error)) http.HandlerFunc {
+    func ReqIDParam[Params, Resp, I any](s *Server, op Operation, fn func(*http.Request, I, *Params) (*Resp, error)) http.HandlerFunc {
         return func(w http.ResponseWriter, r *http.Request) {
-            id, err := strconv.Atoi(r.PathValue("id"))
+            id, err := resolveID[I](r)
             if err != nil {
                 handleResponse[Resp](s, w, r, op, nil, err)
                 return

--- a/templates/server.tmpl
+++ b/templates/server.tmpl
@@ -88,6 +88,8 @@ func (s *Server) DefaultErrorHandler(w http.ResponseWriter, r *http.Request, op 
         resp.Code = http.StatusMethodNotAllowed
     case IsBadRequest(err):
         resp.Code = http.StatusBadRequest
+    case IsInvalidID(err):
+        resp.Code = http.StatusBadRequest
     {{- with $.Config.FeatureEnabled "privacy" }}
         case errors.Is(err, privacy.Deny):
             resp.Code = http.StatusForbidden
@@ -289,7 +291,7 @@ func UseEntContext(db *ent.Client) func(next http.Handler) http.Handler {
     {{- if and $t.ID (($t|getAnnotation).HasOperation $t.Config.Annotations.RestConfig "read") }}
         {{- $opID := getOperationIDName "read" $t nil | zpascal }}
         // {{ $opID }} maps to "GET {{ getPathName "read" $t nil false }}".
-        func (s *Server) {{ $opID }}(r *http.Request, {{ $id }} int) (*ent.{{ $t.Name }}, error) {
+        func (s *Server) {{ $opID }}(r *http.Request, {{ $id }} {{ $t.ID.Type }}) (*ent.{{ $t.Name }}, error) {
             return EagerLoad{{ $t.Name|zsingular }}(s.db.{{ $t.Name }}.Query().Where({{ $t.Package }}.ID({{ $id }}))).Only(r.Context())
         }
     {{- end }}
@@ -306,7 +308,7 @@ func UseEntContext(db *ent.Client) func(next http.Handler) http.Handler {
         {{- if and $e.Unique (($t|getAnnotation).HasOperation $t.Config.Annotations.RestConfig "read") }}
             {{- $opID := getOperationIDName "read" $t $e | zpascal }}
             // {{ $opID }} maps to "GET {{ getPathName "read" $t $e false }}".
-            func (s *Server) {{ $opID }}(r *http.Request, {{ $id }} int) (*ent.{{ $e.Type.Name }}, error) {
+            func (s *Server) {{ $opID }}(r *http.Request, {{ $id }} {{ $t.ID.Type }}) (*ent.{{ $e.Type.Name }}, error) {
                 return EagerLoad{{ $e.Type.Name|zsingular }}(s.db.{{ $t.Name }}.Query().Where({{ $t.Package }}.ID({{ $id }})).Query{{ $e.StructField }}()).Only(r.Context())
             }
         {{- end }}
@@ -315,7 +317,7 @@ func UseEntContext(db *ent.Client) func(next http.Handler) http.Handler {
         {{- if and (not $e.Unique) (($t|getAnnotation).HasOperation $t.Config.Annotations.RestConfig "list") }}
             {{- $opID := getOperationIDName "list" $t $e | zpascal }}
             // {{ $opID }} maps to "GET {{ getPathName "list" $t $e false }}".
-            func (s *Server) {{ $opID }}(r *http.Request, {{ $id }} int, p *List{{ $e.Type.Name|zsingular }}Params) (*PagedResponse[ent.{{ $e.Type.Name }}], error) {
+            func (s *Server) {{ $opID }}(r *http.Request, {{ $id }} {{ $t.ID.Type }}, p *List{{ $e.Type.Name|zsingular }}Params) (*PagedResponse[ent.{{ $e.Type.Name }}], error) {
                 return p.Exec(r.Context(), s.db.{{ $t.Name }}.Query().Where({{ $t.Package }}.ID({{ $id }})).Query{{ $e.StructField }}())
             }
         {{- end }}
@@ -334,7 +336,7 @@ func UseEntContext(db *ent.Client) func(next http.Handler) http.Handler {
     {{- if and $t.ID (($t|getAnnotation).HasOperation $t.Config.Annotations.RestConfig "update") }}
         {{- $opID := getOperationIDName "update" $t nil | zpascal }}
         // {{ $opID }} maps to "PATCH {{ getPathName "update" $t nil false }}".
-        func (s *Server) {{ $opID }}(r *http.Request, {{ $id }} int, p *Update{{ $t.Name|zsingular }}Params) (*ent.{{ $t.Name }}, error) {
+        func (s *Server) {{ $opID }}(r *http.Request, {{ $id }} {{ $t.ID.Type }}, p *Update{{ $t.Name|zsingular }}Params) (*ent.{{ $t.Name }}, error) {
             return p.Exec(r.Context(), s.db.{{ $t.Name }}.UpdateOneID({{ $id }}), s.db.{{ $t.Name }}.Query())
         }
     {{- end }}
@@ -343,7 +345,7 @@ func UseEntContext(db *ent.Client) func(next http.Handler) http.Handler {
     {{- if and $t.ID (($t|getAnnotation).HasOperation $t.Config.Annotations.RestConfig "delete") }}
         {{- $opID := getOperationIDName "delete" $t nil | zpascal }}
         // {{ $opID }} maps to "DELETE {{ getPathName "delete" $t nil false }}".
-        func (s *Server) {{ $opID }}(r *http.Request, {{ $id }} int) (*struct{}, error) {
+        func (s *Server) {{ $opID }}(r *http.Request, {{ $id }} {{ $t.ID.Type }}) (*struct{}, error) {
             return nil, s.db.{{ $t.Name }}.DeleteOneID({{ $id }}).Exec(r.Context())
         }
     {{- end }}

--- a/templates/update.tmpl
+++ b/templates/update.tmpl
@@ -54,12 +54,12 @@ import (
                 {{ $e.Field.StructField }} Option[{{ if $e.Field.Nillable }}*{{ end }}{{ $e.Field.Type }}] {{ template "helper/rest/edge/tag" (dict "Field" $e.Field) }}
             {{- else if $e.Unique }}
                 {{- template "helper/rest/fields/comment" $e }}
-                {{ $e.StructField }} Option[{{ if not $e.Unique }}[]{{ else if $e.Optional }}*{{ end }}{{ $e.Type.IDType.String }}] {{ template "helper/rest/edge/tag" (dict "Edge" $e) }}
+                {{ $e.StructField }} Option[{{ if not $e.Unique }}[]{{ else if $e.Optional }}*{{ end }}{{ $e.Type.ID.Type }}] {{ template "helper/rest/edge/tag" (dict "Edge" $e) }}
             {{- else }}
                 {{- range $prefix := list "Add" "Remove" "" }}
                     {{- if and (not $e.Annotations.Rest.EdgeUpdateBulk) (not $prefix) }}{{ continue }}{{ end }}
                     {{- template "helper/rest/fields/comment" $e }}
-                    {{ $prefix }}{{ $e.StructField }} Option[{{ if not $e.Unique }}[]{{ else if $e.Optional }}*{{ end }}{{ $e.Type.IDType.String }}] {{ template "helper/rest/edge/tag" (dict "Edge" $e "Prefix" $prefix) }}
+                    {{ $prefix }}{{ $e.StructField }} Option[{{ if not $e.Unique }}[]{{ else if $e.Optional }}*{{ end }}{{ $e.Type.ID.Type }}] {{ template "helper/rest/edge/tag" (dict "Edge" $e "Prefix" $prefix) }}
                 {{- end }}
             {{- end }}
         {{- end }}

--- a/testdata/schema/follows.go
+++ b/testdata/schema/follows.go
@@ -20,7 +20,7 @@ type Follows struct {
 func (Follows) Fields() []ent.Field {
 	return []ent.Field{
 		field.Time("followed_at").Default(time.Now),
-		field.Int("user_id"),
+		field.String("user_id"),
 		field.Int("pet_id"),
 	}
 }

--- a/testdata/schema/friendship.go
+++ b/testdata/schema/friendship.go
@@ -20,8 +20,8 @@ func (Friendship) Fields() []ent.Field {
 	return []ent.Field{
 		field.Time("created_at").
 			Default(time.Now),
-		field.Int("user_id"),
-		field.Int("friend_id"),
+		field.String("user_id"),
+		field.String("friend_id"),
 	}
 }
 

--- a/testdata/schema/user.go
+++ b/testdata/schema/user.go
@@ -18,6 +18,11 @@ type User struct {
 
 func (User) Fields() []ent.Field {
 	return []ent.Field{
+		field.String("id").
+			Immutable().
+			NotEmpty().
+			Unique().
+			Comment("The username (id) of the user."),
 		field.String("name").Comment("Name of the identity."),
 		field.Enum("type").
 			NamedValues(


### PR DESCRIPTION
## 🚀 Changes proposed by this PR

- **BREAKING**: renamed `Config.AllowClientUUIDs` to `Config.AllowClientIDs` to indicate that it's not specific to UUIDs, but rather any scenario where you want to allow the client to provide their own ID for the `CREATE` request.
  - Ensure `Config.AllowClientIDs` actually has an impact. Previously, it only added it to the spec, but didn't add it to the server request handling logic. It's now correctly added to the spec, and the server knows how to handle when a custom ID is provided.
  - `WithAllowClientIDs` can now be used to toggle this feature on/off on a per-schema basis.
- Added support for ID fields with the underlying types of: `string`, `int`, and any other custom type that implements the following interfaces: `encoding.TextUnmarshaler`, `json.Unmarshaler`, and `encoding.BinaryUnmarshaler` (in that order of priority).
  - Switched some tests to include string and UUID-based ID fields.
- Fixed an issue where if an ID field had a custom package type, it may not import the correct package (e.g. ` uuid.UUID{}` could import Google's library, or some other random one that you happen to have locally).
- Improved wording of the `id` field in the spec, when IDs can be generated on behalf of the `CREATE` request, when using `AllowClientIDs`.
- Filter fields in the spec now inherit the `format` field. For example, `id.in` on `/users` now is an array of `uuid` format type.
- Removed performance suggestion wording from the spec for `?pretty=true`.


### 🔗 Related bug reports/feature requests

- implements #69
- closes #70
- implements #76

### 🧰 Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that causes existing functionality to not work as expected).