### PR TITLE
bug: fix incorrect field name singularize

### DIFF
--- a/templates/create.tmpl
+++ b/templates/create.tmpl
@@ -122,7 +122,7 @@ import (
                 {{- end }}
             {{- else }}
                 {{- if not $e.Unique }}
-                    builder.Add{{ $e.StructField|zsingular }}IDs(c.{{ $e.StructField }}...)
+                    builder.Add{{ $e.Name|zsingular|pascal }}IDs(c.{{ $e.StructField }}...)
                 {{- else if $e.Optional }}
                     if c.{{ $e.StructField }} != nil {
                         builder.Set{{ $e.StructField }}ID(*c.{{ $e.StructField }})

--- a/templates/update.tmpl
+++ b/templates/update.tmpl
@@ -121,7 +121,7 @@ import (
                 {{- if not $e.Unique }}
                     {{- range $prefix := list "Add" "Remove" }}
                         if v, ok := u.{{ $prefix }}{{ $e.StructField }}.Get(); ok && v != nil {
-                            builder.{{ $prefix }}{{ $e.StructField|singular }}IDs(v...)
+                            builder.{{ $prefix }}{{ $e.Name|singular|pascal }}IDs(v...)
                         }
                     {{- end }}
                     {{- if $e.Annotations.Rest.EdgeUpdateBulk }}
@@ -129,7 +129,7 @@ import (
                         if v, ok := u.{{ $e.StructField }}.Get(); ok && !u.Add{{ $e.StructField }}.Present() && !u.Remove{{ $e.StructField }}.Present() {
                             builder.Clear{{ $e.StructField }}()
                             if v != nil {
-                                builder.Add{{ $e.StructField|singular }}IDs(v...)
+                                builder.Add{{ $e.Name|singular|pascal }}IDs(v...)
                             }
                         }
                     {{- end }}


### PR DESCRIPTION
## 🚀 Changes proposed by this PR

Due to the prior use of the pascal function, some words (children, people, etc.) were not converted to a singular.
PR changes the logic so that now the name of the field is converted back to a singular, and then it takes pascal.

```go
package schema

import (
	"entgo.io/contrib/entgql"
	"entgo.io/ent"
	"entgo.io/ent/dialect/entsql"
	"entgo.io/ent/schema"
	"entgo.io/ent/schema/edge"
	"entgo.io/ent/schema/field"
	"github.com/google/uuid"
)

type Person struct {
	ent.Schema
}

// Annotations(), Fields()

func (Person) Edges() []ent.Edge {
	return []ent.Edge{
		edge.To("parent", Person.Type).
			From("children"),
	}
}
```

ex, create.go:

```go
// other
func (c *CreatePersonParams) ApplyInputs(builder *ent.PersonCreate) *ent.PersonCreate {
        // other
	builder.AddChildrenIDs(c.Children...) // <- error
        // other
	return builder
}
// other
```

### 🧰 Type of change

<!-- REQUIRED: Please mark which one applies to this change, ❌ remove the others. -->
- [x] Breaking change (fix or feature that causes existing functionality to not work as expected).

### 🤝 Requirements

- [x] ✍ I have read and agree to this projects [Code of Conduct](../../blob/master/.github/CODE_OF_CONDUCT.md).
- [x] ✍ I have read and agree to this projects [Contribution Guidelines](../../blob/master/.github/CONTRIBUTING.md).
- [x] ✍ I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] 🔎 I have performed a self-review of my own changes.
- [x] 🎨 My changes follow the style guidelines of this project.
<!-- Include the below if this is a code change, if just documentation, ❌ remove this section. -->
- [x] 💬 My changes as properly commented, primarily for hard-to-understand areas.
