### PR TITLE
fix: rename order parameter to avoid entity name collision

### DIFF
--- a/_examples/kitchensink/internal/database/ent/rest/sorting.go
+++ b/_examples/kitchensink/internal/database/ent/rest/sorting.go
@@ -221,9 +221,9 @@ func isSpecializedSort(parts []string) (isCount, isSum bool) {
 
 // applySortingCategory applies sorting to the query based on the provided sort and
 // order fields. Note that all inputs provided MUST ALREADY BE VALIDATED.
-func applySortingCategory(query *ent.CategoryQuery, field string, order orderDirection) *ent.CategoryQuery {
+func applySortingCategory(query *ent.CategoryQuery, field string, erOrder orderDirection) *ent.CategoryQuery {
 	if parts := strings.Split(field, "."); len(parts) > 1 {
-		dir := withOrderTerm(order)
+		dir := withOrderTerm(erOrder)
 
 		isCount, isSum := isSpecializedSort(parts)
 
@@ -242,14 +242,14 @@ func applySortingCategory(query *ent.CategoryQuery, field string, order orderDir
 	if field == "random" {
 		return query.Order(sql.OrderByRand())
 	}
-	return query.Order(withFieldSelector(field, order))
+	return query.Order(withFieldSelector(field, erOrder))
 }
 
 // applySortingFollow applies sorting to the query based on the provided sort and
 // order fields. Note that all inputs provided MUST ALREADY BE VALIDATED.
-func applySortingFollow(query *ent.FollowsQuery, field string, order orderDirection) *ent.FollowsQuery {
+func applySortingFollow(query *ent.FollowsQuery, field string, erOrder orderDirection) *ent.FollowsQuery {
 	if parts := strings.Split(field, "."); len(parts) > 1 {
-		dir := withOrderTerm(order)
+		dir := withOrderTerm(erOrder)
 
 		switch parts[0] {
 		case follows.EdgeUser:
@@ -261,14 +261,14 @@ func applySortingFollow(query *ent.FollowsQuery, field string, order orderDirect
 	if field == "random" {
 		return query.Order(sql.OrderByRand())
 	}
-	return query.Order(withFieldSelector(field, order))
+	return query.Order(withFieldSelector(field, erOrder))
 }
 
 // applySortingFriendship applies sorting to the query based on the provided sort and
 // order fields. Note that all inputs provided MUST ALREADY BE VALIDATED.
-func applySortingFriendship(query *ent.FriendshipQuery, field string, order orderDirection) *ent.FriendshipQuery {
+func applySortingFriendship(query *ent.FriendshipQuery, field string, erOrder orderDirection) *ent.FriendshipQuery {
 	if parts := strings.Split(field, "."); len(parts) > 1 {
-		dir := withOrderTerm(order)
+		dir := withOrderTerm(erOrder)
 
 		switch parts[0] {
 		case friendship.EdgeUser:
@@ -280,14 +280,14 @@ func applySortingFriendship(query *ent.FriendshipQuery, field string, order orde
 	if field == "random" {
 		return query.Order(sql.OrderByRand())
 	}
-	return query.Order(withFieldSelector(field, order))
+	return query.Order(withFieldSelector(field, erOrder))
 }
 
 // applySortingPet applies sorting to the query based on the provided sort and
 // order fields. Note that all inputs provided MUST ALREADY BE VALIDATED.
-func applySortingPet(query *ent.PetQuery, field string, order orderDirection) *ent.PetQuery {
+func applySortingPet(query *ent.PetQuery, field string, erOrder orderDirection) *ent.PetQuery {
 	if parts := strings.Split(field, "."); len(parts) > 1 {
-		dir := withOrderTerm(order)
+		dir := withOrderTerm(erOrder)
 
 		isCount, isSum := isSpecializedSort(parts)
 
@@ -335,14 +335,14 @@ func applySortingPet(query *ent.PetQuery, field string, order orderDirection) *e
 	if field == "random" {
 		return query.Order(sql.OrderByRand())
 	}
-	return query.Order(withFieldSelector(field, order))
+	return query.Order(withFieldSelector(field, erOrder))
 }
 
 // applySortingPost applies sorting to the query based on the provided sort and
 // order fields. Note that all inputs provided MUST ALREADY BE VALIDATED.
-func applySortingPost(query *ent.PostQuery, field string, order orderDirection) *ent.PostQuery {
+func applySortingPost(query *ent.PostQuery, field string, erOrder orderDirection) *ent.PostQuery {
 	if parts := strings.Split(field, "."); len(parts) > 1 {
-		dir := withOrderTerm(order)
+		dir := withOrderTerm(erOrder)
 
 		switch parts[0] {
 		case post.EdgeAuthor:
@@ -352,14 +352,14 @@ func applySortingPost(query *ent.PostQuery, field string, order orderDirection) 
 	if field == "random" {
 		return query.Order(sql.OrderByRand())
 	}
-	return query.Order(withFieldSelector(field, order))
+	return query.Order(withFieldSelector(field, erOrder))
 }
 
 // applySortingSetting applies sorting to the query based on the provided sort and
 // order fields. Note that all inputs provided MUST ALREADY BE VALIDATED.
-func applySortingSetting(query *ent.SettingsQuery, field string, order orderDirection) *ent.SettingsQuery {
+func applySortingSetting(query *ent.SettingsQuery, field string, erOrder orderDirection) *ent.SettingsQuery {
 	if parts := strings.Split(field, "."); len(parts) > 1 {
-		dir := withOrderTerm(order)
+		dir := withOrderTerm(erOrder)
 
 		isCount, isSum := isSpecializedSort(parts)
 
@@ -378,14 +378,14 @@ func applySortingSetting(query *ent.SettingsQuery, field string, order orderDire
 	if field == "random" {
 		return query.Order(sql.OrderByRand())
 	}
-	return query.Order(withFieldSelector(field, order))
+	return query.Order(withFieldSelector(field, erOrder))
 }
 
 // applySortingUser applies sorting to the query based on the provided sort and
 // order fields. Note that all inputs provided MUST ALREADY BE VALIDATED.
-func applySortingUser(query *ent.UserQuery, field string, order orderDirection) *ent.UserQuery {
+func applySortingUser(query *ent.UserQuery, field string, erOrder orderDirection) *ent.UserQuery {
 	if parts := strings.Split(field, "."); len(parts) > 1 {
-		dir := withOrderTerm(order)
+		dir := withOrderTerm(erOrder)
 
 		isCount, isSum := isSpecializedSort(parts)
 
@@ -449,5 +449,5 @@ func applySortingUser(query *ent.UserQuery, field string, order orderDirection) 
 	if field == "random" {
 		return query.Order(sql.OrderByRand())
 	}
-	return query.Order(withFieldSelector(field, order))
+	return query.Order(withFieldSelector(field, erOrder))
 }

--- a/templates/sorting.tmpl
+++ b/templates/sorting.tmpl
@@ -118,10 +118,10 @@ func isSpecializedSort(parts []string) (isCount, isSum bool) {
 
     // applySorting{{ $t.Name|zsingular }} applies sorting to the query based on the provided sort and
     // order fields. Note that all inputs provided MUST ALREADY BE VALIDATED.
-    func applySorting{{ $t.Name|zsingular }}(query *ent.{{ $t.Name }}Query, field string, order orderDirection) *ent.{{ $t.Name }}Query {
+    func applySorting{{ $t.Name|zsingular }}(query *ent.{{ $t.Name }}Query, field string, erOrder orderDirection) *ent.{{ $t.Name }}Query {
         {{- if $t.Edges }}
         if parts := strings.Split(field, "."); len(parts) > 1 {
-            dir := withOrderTerm(order)
+            dir := withOrderTerm(erOrder)
 
             {{- range $e := $t.Edges }}
                 {{ if not $e.Unique }}
@@ -156,7 +156,7 @@ func isSpecializedSort(parts []string) (isCount, isSum bool) {
         if field == "random" {
             return query.Order(sql.OrderByRand())
         }
-        return query.Order(withFieldSelector(field, order))
+        return query.Order(withFieldSelector(field, erOrder))
     }
 {{- end }}{{/* end range */}}
 {{- end }}{{/* end template */}}


### PR DESCRIPTION
## Summary

When an entity is named `Order`, the generated `applySorting` function has a parameter named `order` that shadows the ent-generated `order` package import (e.g. `order.EdgeItems`), causing a compilation error.

This renames the parameter to `erOrder` (entrest-prefixed) to avoid the collision. The convention of prefixing entrest-internal template variables prevents clashes with user-defined entity names.

### Example of the problem

For a schema with an `Order` entity that has edges, the generated code would be:

```go
import "your/ent/order"

func applySortingOrder(query *ent.OrderQuery, field string, order orderDirection) *ent.OrderQuery {
    // ...
    case order.EdgeItems:  // ERROR: order refers to the parameter, not the package
```

After this fix:

```go
func applySortingOrder(query *ent.OrderQuery, field string, erOrder orderDirection) *ent.OrderQuery {
    // ...
    case order.EdgeItems:  // OK: order is the package import
```

## Changes

- `templates/sorting.tmpl`: Rename `order` parameter to `erOrder` in the `applySorting` template function
- `_examples/kitchensink/.../sorting.go`: Regenerated example code

## Test plan

- [x] Kitchensink example regenerated and builds cleanly
- [x] Verified pre-existing test suite passes/fails identically (upstream has an unrelated `libopenapi-validator` dependency build issue)